### PR TITLE
Add additional feature constants to MalojaScrobbler

### DIFF
--- a/clients/MalojaScrobbler.js
+++ b/clients/MalojaScrobbler.js
@@ -3,7 +3,7 @@ import request from 'superagent';
 import dayjs from 'dayjs';
 import {buildTrackString, playObjDataMatch, setIntersection, sortByPlayDate, truncateStringToLength} from "../utils.js";
 
-const feat = ["ft.", "ft", "feat.", "feat", "featuring", "Ft.", "Ft", "Feat.", "Feat", "Featuring"];
+const feat = ["ft.", "ft", "feat.", "feat", "featuring", "Ft.", "Ft", "Feat.", "Feat", "Featuring", "FT.", "FT", "FEAT.", "FEAT", "FEATURING"];
 
 export default class MalojaScrobbler extends AbstractScrobbleClient {
 


### PR DESCRIPTION
This request adds additional, capitalized terms to the MalojaScrobbler feature constant list. Currently, songs that contain any form of "feat" in all caps are scrobbled verbatim - e.g., the Spotify Listing for "Loyalty" by Kendrick Lamar is scrobbled as ` Rihanna, Kendrick Lamar – LOYALTY. FEAT. RIHANNA.`

