### PR TITLE
Fix: Jellyfin source

### DIFF
--- a/sources/JellyfinSource.js
+++ b/sources/JellyfinSource.js
@@ -45,7 +45,7 @@ export default class JellyfinSource extends MemorySource {
         const {
             ServerId,
             ServerName,
-            Username,
+            NotificationUsername,
             UserId,
             NotificationType,
             UtcTimestamp,
@@ -76,7 +76,7 @@ export default class JellyfinSource extends MemorySource {
                 event: NotificationType,
                 mediaType: ItemType,
                 sourceId: ItemId,
-                user: Username,
+                user: NotificationUsername,
                 server: ServerName,
                 source: 'Jellyfin',
                 newFromSource,
@@ -97,7 +97,7 @@ export default class JellyfinSource extends MemorySource {
 
         if (this.users !== undefined) {
             if (user === undefined) {
-                this.logger.warn(`Config defined users but payload contained no user info${hint}`);
+                this.logger.warn(`Config defined users but payload contained no user info`);
             } else if (!this.users.includes(user.toLocaleLowerCase())) {
                 this.logger.debug(`Will not scrobble event because author was not an allowed user: ${user}`, {
                     artists,


### PR DESCRIPTION
First off, thanks for all your work here! Tried the program out but noticed a couple of bugs when using a Jellyfin source, so I thought I'd take a crack at fixing them.

- User info was always empty from the webhook payload. The field  is `NotificationUsername` rather than `Username`
- Null reference error when trying to log an instance when the User info is undefined. The variable `hint` isn't defined here; wasn't sure what you wanted here as a hint, but for now I removed it to prevent errors!

