### PR TITLE
Enable more agressive scrobble checking behavior

### DIFF
--- a/src/backend/common/infrastructure/config/client/index.ts
+++ b/src/backend/common/infrastructure/config/client/index.ts
@@ -37,6 +37,15 @@ export interface CommonClientOptions extends RequestRetryOptions {
      * @examples [true]
      * */
     refreshEnabled?: boolean
+    /**
+     * Force client to always refresh scrobbled plays from service before scrobbling new play
+     *
+     * WARNING: This will cause increased load on the scrobble service and potentially slow down scrobble speed as well. This should be used as a debugging tool and not be always-on.
+     *
+     * @default false
+     * @examples [false]
+     * */
+    refreshForce?: boolean
 
     /**
      * The number of tracks to retrieve on initial refresh (related to scrobbleBacklogCount). If not specified this is the maximum supported for the client.

--- a/src/backend/common/infrastructure/config/client/index.ts
+++ b/src/backend/common/infrastructure/config/client/index.ts
@@ -38,14 +38,15 @@ export interface CommonClientOptions extends RequestRetryOptions {
      * */
     refreshEnabled?: boolean
     /**
-     * Force client to always refresh scrobbled plays from service before scrobbling new play
+     * Force client to refresh scrobbled plays from upstream service if last refresh was at least X seconds ago
      *
-     * WARNING: This will cause increased load on the scrobble service and potentially slow down scrobble speed as well. This should be used as a debugging tool and not be always-on.
+     * **In most case this setting should NOT be used.** MS intelligently refreshes based on activity so using this setting may increase upstream service load and slow down scrobbles.
      *
-     * @default false
-     * @examples [false]
+     * This setting should only be used in specific scenarios where MS is handling multiple "relaying" client-services (IE lfm -> lz -> lfm) and there is the potential for a client to be out of sync after more than a few seconds.
+     *
+     * @examples [3]
      * */
-    refreshForce?: boolean
+    refreshStaleAfter?: number
 
     /**
      * The number of tracks to retrieve on initial refresh (related to scrobbleBacklogCount). If not specified this is the maximum supported for the client.

--- a/src/backend/common/schema/aio-client.json
+++ b/src/backend/common/schema/aio-client.json
@@ -57,6 +57,15 @@
                     "title": "refreshEnabled",
                     "type": "boolean"
                 },
+                "refreshForce": {
+                    "default": false,
+                    "description": "Force client to always refresh scrobbled plays from service before scrobbling new play\n\nWARNING: This will cause increased load on the scrobble service and potentially slow down scrobble speed as well. This should be used as a debugging tool and not be always-on.",
+                    "examples": [
+                        false
+                    ],
+                    "title": "refreshForce",
+                    "type": "boolean"
+                },
                 "refreshInitialCount": {
                     "description": "The number of tracks to retrieve on initial refresh (related to scrobbleBacklogCount). If not specified this is the maximum supported for the client.",
                     "title": "refreshInitialCount",

--- a/src/backend/common/schema/aio.json
+++ b/src/backend/common/schema/aio.json
@@ -346,6 +346,15 @@
                     "title": "refreshEnabled",
                     "type": "boolean"
                 },
+                "refreshForce": {
+                    "default": false,
+                    "description": "Force client to always refresh scrobbled plays from service before scrobbling new play\n\nWARNING: This will cause increased load on the scrobble service and potentially slow down scrobble speed as well. This should be used as a debugging tool and not be always-on.",
+                    "examples": [
+                        false
+                    ],
+                    "title": "refreshForce",
+                    "type": "boolean"
+                },
                 "refreshInitialCount": {
                     "description": "The number of tracks to retrieve on initial refresh (related to scrobbleBacklogCount). If not specified this is the maximum supported for the client.",
                     "title": "refreshInitialCount",
@@ -415,6 +424,15 @@
                         true
                     ],
                     "title": "refreshEnabled",
+                    "type": "boolean"
+                },
+                "refreshForce": {
+                    "default": false,
+                    "description": "Force client to always refresh scrobbled plays from service before scrobbling new play\n\nWARNING: This will cause increased load on the scrobble service and potentially slow down scrobble speed as well. This should be used as a debugging tool and not be always-on.",
+                    "examples": [
+                        false
+                    ],
+                    "title": "refreshForce",
                     "type": "boolean"
                 },
                 "refreshInitialCount": {

--- a/src/backend/common/schema/client.json
+++ b/src/backend/common/schema/client.json
@@ -54,6 +54,15 @@
                     "title": "refreshEnabled",
                     "type": "boolean"
                 },
+                "refreshForce": {
+                    "default": false,
+                    "description": "Force client to always refresh scrobbled plays from service before scrobbling new play\n\nWARNING: This will cause increased load on the scrobble service and potentially slow down scrobble speed as well. This should be used as a debugging tool and not be always-on.",
+                    "examples": [
+                        false
+                    ],
+                    "title": "refreshForce",
+                    "type": "boolean"
+                },
                 "refreshInitialCount": {
                     "description": "The number of tracks to retrieve on initial refresh (related to scrobbleBacklogCount). If not specified this is the maximum supported for the client.",
                     "title": "refreshInitialCount",

--- a/src/backend/scrobblers/AbstractScrobbleClient.ts
+++ b/src/backend/scrobblers/AbstractScrobbleClient.ts
@@ -521,11 +521,15 @@ ${closestMatch.breakdowns.join('\n')}`, {leaf: ['Dupe Check']});
         this.logger.info('Scrobble processing started');
         this.emitEvent('statusChange', {status: 'Running'});
 
+        const {
+            refreshForce = false
+        } = this.config.options || {};
+
         try {
             this.scrobbling = true;
             while (!this.shouldStopScrobbleProcessing()) {
                 while (this.queuedScrobbles.length > 0) {
-                    if (this.lastScrobbleCheck.unix() < this.getLatestQueuePlayDate().unix()) {
+                    if (refreshForce || (this.lastScrobbleCheck.unix() < this.getLatestQueuePlayDate().unix())) {
                         await this.refreshScrobbles();
                     }
                     const currQueuedPlay = this.queuedScrobbles.shift();

--- a/src/backend/scrobblers/LastfmScrobbler.ts
+++ b/src/backend/scrobblers/LastfmScrobbler.ts
@@ -46,9 +46,7 @@ export default class LastfmScrobbler extends AbstractScrobbleClient {
         }
     }
 
-    refreshScrobbles = async (limit = this.MAX_STORED_SCROBBLES) => {
-        if (this.refreshEnabled) {
-            this.logger.debug('Refreshing recent scrobbles');
+    getScrobblesForRefresh = async (limit: number) => {
             const resp = await this.api.callApi<UserGetRecentTracksResponse>((client: any) => client.userGetRecentTracks({
                 user: this.api.user,
                 sk: this.api.client.sessionKey,
@@ -60,7 +58,7 @@ export default class LastfmScrobbler extends AbstractScrobbleClient {
                     track: list = [],
                 }
             } = resp;
-            this.recentScrobbles = list.reduce((acc: any, x: any) => {
+            return list.reduce((acc: any, x: any) => {
                 try {
                     const formatted = LastfmApiClient.formatPlayObj(x);
                     const {
@@ -91,17 +89,6 @@ export default class LastfmScrobbler extends AbstractScrobbleClient {
                     return acc;
                 }
             }, []);
-            this.logger.debug(`Found ${this.recentScrobbles.length} recent scrobbles`);
-            if (this.recentScrobbles.length > 0) {
-                const [{data: {playDate: newestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(-1);
-                const [{data: {playDate: oldestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(0, 1);
-                this.newestScrobbleTime = newestScrobbleTime;
-                this.oldestScrobbleTime = oldestScrobbleTime;
-
-                this.filterScrobbledTracks();
-            }
-        }
-        this.lastScrobbleCheck = dayjs();
     }
 
     cleanSourceSearchTitle = (playObj: PlayObject) => {

--- a/src/backend/scrobblers/ListenbrainzScrobbler.ts
+++ b/src/backend/scrobblers/ListenbrainzScrobbler.ts
@@ -59,22 +59,8 @@ export default class ListenbrainzScrobbler extends AbstractScrobbleClient {
         }
     }
 
-    refreshScrobbles = async (limit = this.MAX_STORED_SCROBBLES) => {
-        if (this.refreshEnabled) {
-            this.logger.debug('Refreshing recent scrobbles');
-            const resp = await this.api.getRecentlyPlayed(limit);
-            this.logger.debug(`Found ${resp.length} recent scrobbles`);
-            this.recentScrobbles = resp;
-            if (this.recentScrobbles.length > 0) {
-                const [{data: {playDate: newestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(-1);
-                const [{data: {playDate: oldestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(0, 1);
-                this.newestScrobbleTime = newestScrobbleTime;
-                this.oldestScrobbleTime = oldestScrobbleTime;
-
-                this.filterScrobbledTracks();
-            }
-        }
-        this.lastScrobbleCheck = dayjs();
+    getScrobblesForRefresh = async (limit: number) => {
+        return await this.api.getRecentlyPlayed(limit);
     }
 
     alreadyScrobbled = async (playObj: PlayObject, log = false) => (await this.existingScrobble(playObj)) !== undefined

--- a/src/backend/scrobblers/MalojaScrobbler.ts
+++ b/src/backend/scrobblers/MalojaScrobbler.ts
@@ -299,28 +299,15 @@ export default class MalojaScrobbler extends AbstractScrobbleClient {
         }
     }
 
-    refreshScrobbles = async (limit = this.MAX_STORED_SCROBBLES) => {
-        if (this.refreshEnabled) {
-            this.logger.debug('Refreshing recent scrobbles');
-            const {url} = this.config.data;
-            const resp = await this.callApi(request.get(`${url}/apis/mlj_1/scrobbles?perpage=${limit}`));
-            const {
-                body: {
-                    list = [],
-                } = {},
-            } = resp;
-            this.logger.debug(`Found ${list.length} recent scrobbles`);
-            this.recentScrobbles = list.map((x: any) => this.formatPlayObj(x));
-            if (this.recentScrobbles.length > 0) {
-                const [{data: {playDate: newestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(-1);
-                const [{data: {playDate: oldestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(0, 1);
-                this.newestScrobbleTime = newestScrobbleTime;
-                this.oldestScrobbleTime = oldestScrobbleTime;
-
-                this.filterScrobbledTracks();
-            }
-        }
-        this.lastScrobbleCheck = dayjs();
+    getScrobblesForRefresh = async (limit: number) => {
+        const {url} = this.config.data;
+        const resp = await this.callApi(request.get(`${url}/apis/mlj_1/scrobbles?perpage=${limit}`));
+        const {
+            body: {
+                list = [],
+            } = {},
+        } = resp;
+        return list.map((x: any) => this.formatPlayObj(x));
     }
 
     cleanSourceSearchTitle = (playObj: PlayObject) => {

--- a/src/backend/tests/scrobbler/TestScrobbler.ts
+++ b/src/backend/tests/scrobbler/TestScrobbler.ts
@@ -6,6 +6,9 @@ import { Notifiers } from "../../notifier/Notifiers.js";
 import AbstractScrobbleClient from "../../scrobblers/AbstractScrobbleClient.js";
 
 export class TestScrobbler extends AbstractScrobbleClient {
+    protected async getScrobblesForRefresh(limit: number): Promise<PlayObject[]> {
+        return [];
+    }
 
     constructor() {
         const logger = loggerTest;

--- a/src/backend/tests/scrobbler/scrobblers.test.ts
+++ b/src/backend/tests/scrobbler/scrobblers.test.ts
@@ -427,12 +427,13 @@ describe('Detects duplicate and unique scrobbles using actively tracked scrobble
 
 describe('Manages scrobble queue', function() {
 
-    before(function() {
+    before(async function() {
+        await testScrobbler.initialize();
         testScrobbler.recentScrobbles = normalizedWithMixedDur;
         testScrobbler.scrobbleSleep = 500;
         testScrobbler.scrobbleDelay = 0;
         testScrobbler.lastScrobbleCheck = dayjs().subtract(60, 'seconds');
-        testScrobbler.initScrobbleMonitoring();
+        testScrobbler.initScrobbleMonitoring().catch(console.error);
     });
 
     it('Scrobbles a uniquely queued play', async function() {


### PR DESCRIPTION
Changes to potentially address duplicate scrobble issues when client<-->source feedback loops occur #173 

### ~~Force Scrobble Refresh~~

~~Update scrobble config options to enable refreshing upstream service existing scrobbles in MS **on every scrobble** so that MS guarantees it always has the latest existing scrobbles to check for dups.~~

### Refresh Stale At

Force client to refresh scrobbled plays from upstream service if last refresh was at least X seconds ago

`listenbrainz.json` or another scrobble config
```diff
[
  {
    "name": "myScrobbler",
    "data": {
      // ...
    },
+    "options": {
+      "refreshStaleAfter": 5
+    }
  }
]
```

