### PR TITLE
fix(maloja): Improve handling for Maloja warnings-as-errors

### DIFF
--- a/src/backend/common/vendor/maloja/interfaces.ts
+++ b/src/backend/common/vendor/maloja/interfaces.ts
@@ -74,7 +74,7 @@ export interface MalojaScrobbleV3RequestData extends MalojaScrobbleRequestData {
     nofix?: boolean
 }
 
-interface MalojaScrobbleWarning {
+export interface MalojaScrobbleWarning {
     type: string
     value: string[] | string
     desc: string

--- a/src/backend/scrobblers/AbstractScrobbleClient.ts
+++ b/src/backend/scrobblers/AbstractScrobbleClient.ts
@@ -153,6 +153,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
             this.logger.debug('Refreshing recent scrobbles');
             const recent = await this.getScrobblesForRefresh(limit);
             this.logger.debug(`Found ${recent.length} recent scrobbles`);
+            this.recentScrobbles = recent;
             if (this.recentScrobbles.length > 0) {
                 const [{data: {playDate: newestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(-1);
                 const [{data: {playDate: oldestScrobbleTime = dayjs()} = {}} = {}] = this.recentScrobbles.slice(0, 1);

--- a/src/backend/tests/scrobbler/TestScrobbler.ts
+++ b/src/backend/tests/scrobbler/TestScrobbler.ts
@@ -6,14 +6,17 @@ import { Notifiers } from "../../notifier/Notifiers.js";
 import AbstractScrobbleClient from "../../scrobblers/AbstractScrobbleClient.js";
 
 export class TestScrobbler extends AbstractScrobbleClient {
-    protected async getScrobblesForRefresh(limit: number): Promise<PlayObject[]> {
-        return [];
-    }
+
+    testRecentScrobbles: PlayObject[] = [];
 
     constructor() {
         const logger = loggerTest;
         const notifier = new Notifiers(new EventEmitter(), new EventEmitter(), new EventEmitter(), logger);
         super('test', 'Test', {name: 'test'}, notifier, new EventEmitter(), logger);
+    }
+
+    protected async getScrobblesForRefresh(limit: number): Promise<PlayObject[]> {
+        return this.testRecentScrobbles;
     }
 
     doScrobble(playObj: PlayObject): Promise<PlayObject> {


### PR DESCRIPTION
* Fixes incorrect handling for duplicate scrobble error from Maloja 3.2.2 #180
* More defensive Maloja scrobble parsing