### PR TITLE
fix: local documentation

### DIFF
--- a/docsite/docusaurus.config.ts
+++ b/docsite/docusaurus.config.ts
@@ -19,7 +19,7 @@ const config: Config = {
   organizationName: 'foxxmd', // Usually your GitHub org/user name.
   projectName: 'multi-scrobbler', // Usually your repo name.
 
-  trailingSlash: false,
+  trailingSlash: true,
 
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
express-static prefers directories over files when using the extensions option, meaning an extensionless route will always route to the directory instead of the file (expressjs/serve-static#138). This causes URLs like http://localhost:9078/docs/docs/configuration to work when navigating from other pages (due to it being a SPA), but on reload it redirects to http://localhost:9078/docs/docs/configuration/ and returns a 404 (note the trailing slash).

This PR re-enables trailing slashes, which turns this structure:

```
docs
|- configuration
|  |- plex.html
|- configuration.html
```

Into:

```
docs
|- configuration
   |- plex
   |  |- index.html
   |- index.html
```

This fixes local docs (served by the backend).

I've deployed it to GH pages here: https://jackwilsdon.github.io/multi-scrobbler/

All existing (normal) URLs will work - GitHub Pages will just add a trailing slash via a 301 redirect. The only URLs that will no longer work are the ones with extensions (e.g. https://jackwilsdon.github.io/multi-scrobbler/docs/configuration.html), but nothing on the site links to that anyway from what I can tell.

We could only set this option to `true` for GitHub pages, but it seemed neater to use the same option for both.

## Checklist before requesting a review

- [ ] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes



## Issue number and link, if applicable

