### PR TITLE
feat(player): Real time positional player state

### DIFF
--- a/src/backend/common/infrastructure/Atomic.ts
+++ b/src/backend/common/infrastructure/Atomic.ts
@@ -4,7 +4,7 @@ import { Dayjs } from "dayjs";
 import { Request, Response } from "express";
 import { NextFunction, ParamsDictionary, Query } from "express-serve-static-core";
 import { FixedSizeList } from 'fixed-size-list';
-import { PlayMeta, PlayObject } from "../../../core/Atomic.js";
+import { isPlayObject, PlayMeta, PlayObject } from "../../../core/Atomic.js";
 import TupleMap from "../TupleMap.js";
 
 export type SourceType =
@@ -122,13 +122,9 @@ export interface PlayerStateDataMaybePlay {
     timestamp?: Dayjs
 }
 
-export const asPlayerStateData = (obj: object): obj is PlayerStateData => {
-    return 'platformId' in obj && 'play' in obj;
-}
+export const asPlayerStateData = (obj: object): obj is PlayerStateData => asPlayerStateDataMaybePlay(obj) && 'play' in obj && isPlayObject(obj.play)
 
-export const asPlayerStateDataMaybePlay = (obj: object): obj is PlayerStateDataMaybePlay => {
-    return 'platformId' in obj;
-}
+export const asPlayerStateDataMaybePlay = (obj: object): obj is PlayerStateDataMaybePlay => 'platformId' in obj
 
 export interface FormatPlayObjectOptions {
     newFromSource?: boolean

--- a/src/backend/sources/ChromecastSource.ts
+++ b/src/backend/sources/ChromecastSource.ts
@@ -34,7 +34,7 @@ import { difference, genGroupIdStr, parseBool } from "../utils.js";
 import { findCauseByReference } from "../utils/ErrorUtils.js";
 import { discoveryAvahi, discoveryNative } from "../utils/MDNSUtils.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
 interface ChromecastDeviceInfo {
     mdns: MdnsDeviceInfo
@@ -46,7 +46,7 @@ interface ChromecastDeviceInfo {
     applications: Map<string, PlatformApplicationWithContext>
 }
 
-export class ChromecastSource extends MemorySource {
+export class ChromecastSource extends MemoryPositionalSource {
 
     declare config: ChromecastSourceConfig;
 

--- a/src/backend/sources/JRiverSource.ts
+++ b/src/backend/sources/JRiverSource.ts
@@ -7,9 +7,9 @@ import { FormatPlayObjectOptions, InternalConfig } from "../common/infrastructur
 import { JRiverSourceConfig } from "../common/infrastructure/config/source/jriver.js";
 import { Info, JRiverApiClient, PLAYER_STATE } from "../common/vendor/JRiverApiClient.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
-export class JRiverSource extends MemorySource {
+export class JRiverSource extends MemoryPositionalSource {
     declare config: JRiverSourceConfig;
 
     url: URL;

--- a/src/backend/sources/JellyfinApiSource.ts
+++ b/src/backend/sources/JellyfinApiSource.ts
@@ -52,13 +52,11 @@ import {
 import { JellyApiSourceConfig } from "../common/infrastructure/config/source/jellyfin.js";
 import { combinePartsToString, genGroupIdStr, getPlatformIdFromData, joinedUrl, parseBool, } from "../utils.js";
 import { parseArrayFromMaybeString } from "../utils/StringUtils.js";
-import MemorySource from "./MemorySource.js";
-import { PlayerStateOptions } from "./PlayerState/AbstractPlayerState.js";
-import { JellyfinPlayerState } from "./PlayerState/JellyfinPlayerState.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
 const shortDeviceId = truncateStringToLength(10, '');
 
-export default class JellyfinApiSource extends MemorySource {
+export default class JellyfinApiSource extends MemoryPositionalSource {
     users: string[] = [];
 
     client: Jellyfin
@@ -476,7 +474,6 @@ export default class JellyfinApiSource extends MemorySource {
         }
     }
 
-    getNewPlayer = (logger: Logger, id: PlayPlatformId, opts: PlayerStateOptions) => new JellyfinPlayerState(logger, id, opts)
 }
 
 /**

--- a/src/backend/sources/KodiSource.ts
+++ b/src/backend/sources/KodiSource.ts
@@ -4,9 +4,9 @@ import { FormatPlayObjectOptions, InternalConfig } from "../common/infrastructur
 import { KodiSourceConfig } from "../common/infrastructure/config/source/kodi.js";
 import { KodiApiClient } from "../common/vendor/KodiApiClient.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
-export class KodiSource extends MemorySource {
+export class KodiSource extends MemoryPositionalSource {
     declare config: KodiSourceConfig;
 
     client: KodiApiClient;

--- a/src/backend/sources/MPDSource.ts
+++ b/src/backend/sources/MPDSource.ts
@@ -19,7 +19,7 @@ import {
 } from "../common/infrastructure/config/source/mpd.js";
 import { isPortReachable } from "../utils/NetworkUtils.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
 const mpdClient = mpdapiNS.default;
 
@@ -29,7 +29,7 @@ const CLIENT_PLAYER_STATE: Record<PlayerState, ReportedPlayerStatus> = {
     'stop': REPORTED_PLAYER_STATUSES.stopped,
 }
 
-export class MPDSource extends MemorySource {
+export class MPDSource extends MemoryPositionalSource {
     declare config: MPDSourceConfig;
 
     host?: string

--- a/src/backend/sources/MemoryPositionalSource.ts
+++ b/src/backend/sources/MemoryPositionalSource.ts
@@ -1,0 +1,9 @@
+import { Logger } from "@foxxmd/logging";
+import { PlayPlatformId } from "../common/infrastructure/Atomic.js";
+import MemorySource from "./MemorySource.js";
+import { PlayerStateOptions } from "./PlayerState/AbstractPlayerState.js";
+import { PositionalPlayerState } from "./PlayerState/PositionalPlayerState.js";
+
+export class MemoryPositionalSource extends MemorySource {
+    getNewPlayer = (logger: Logger, id: PlayPlatformId, opts: PlayerStateOptions) => new PositionalPlayerState(logger, id, opts)
+}

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -90,7 +90,7 @@ export default class MemorySource extends AbstractSource {
         return record;
     }
 
-    getNewPlayer = (logger: Logger, id: PlayPlatformId, opts: PlayerStateOptions) => new GenericPlayerState(logger, id, opts)
+    getNewPlayer = (logger: Logger, id: PlayPlatformId, opts: PlayerStateOptions): AbstractPlayerState => new GenericPlayerState(logger, id, opts)
 
     setNewPlayer = (idStr: string, logger: Logger, id: PlayPlatformId, opts: PlayerStateOptions = {}) => {
         this.players.set(idStr, this.getNewPlayer(this.logger, id, {
@@ -172,6 +172,9 @@ export default class MemorySource extends AbstractSource {
                     playerState = incomingData;
                 } else {
                     playerState = {play: incomingData, platformId: getPlatformIdFromData(incomingData)};
+                }
+                if(playerState.position === undefined && playerState.play !== undefined && playerState.play.meta.trackProgressPosition !== undefined) {
+                    playerState.position = playerState.play.meta?.trackProgressPosition;
                 }
 
                 const [currPlay, prevPlay] = player.update(playerState);

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -167,7 +167,14 @@ export default class MemorySource extends AbstractSource {
                 }
                 incomingData = relevantDatas[0];
 
-                const [currPlay, prevPlay] = asPlayerStateDataMaybePlay(incomingData) ? player.setState(incomingData.status, incomingData.play) : player.setState(undefined, incomingData);
+                let playerState: PlayerStateDataMaybePlay;
+                if(asPlayerStateDataMaybePlay(incomingData)) {
+                    playerState = incomingData;
+                } else {
+                    playerState = {play: incomingData, platformId: getPlatformIdFromData(incomingData)};
+                }
+
+                const [currPlay, prevPlay] = player.update(playerState);
                 const candidate = prevPlay !== undefined ? prevPlay : currPlay;
                 const playChanged = prevPlay !== undefined;
 

--- a/src/backend/sources/MopidySource.ts
+++ b/src/backend/sources/MopidySource.ts
@@ -15,9 +15,9 @@ import {
 } from "../common/infrastructure/Atomic.js";
 import { MopidySourceConfig } from "../common/infrastructure/config/source/mopidy.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
-export class MopidySource extends MemorySource {
+export class MopidySource extends MemoryPositionalSource {
     declare config: MopidySourceConfig;
 
     albumBlacklist: string[] = [];

--- a/src/backend/sources/MusikcubeSource.ts
+++ b/src/backend/sources/MusikcubeSource.ts
@@ -22,7 +22,7 @@ import {
 } from "../common/infrastructure/config/source/musikcube.js";
 import { sleep } from "../utils.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
 const CLIENT_STATE = {
     0: 'connecting',
@@ -31,7 +31,7 @@ const CLIENT_STATE = {
     3: 'closed'
 }
 
-export class MusikcubeSource extends MemorySource {
+export class MusikcubeSource extends MemoryPositionalSource {
     declare config: MusikcubeSourceConfig;
 
     url: URL;

--- a/src/backend/sources/PlayerState/AbstractPlayerState.ts
+++ b/src/backend/sources/PlayerState/AbstractPlayerState.ts
@@ -5,6 +5,7 @@ import { buildTrackString } from "../../../core/StringUtils.js";
 import {
     CALCULATED_PLAYER_STATUSES,
     CalculatedPlayerStatus,
+    PlayerStateDataMaybePlay,
     PlayPlatformId,
     REPORTED_PLAYER_STATUSES,
     ReportedPlayerStatus,
@@ -121,8 +122,11 @@ export abstract class AbstractPlayerState {
         return status !== 'paused' && status !== 'stopped';
     }
 
-    setState(status?: ReportedPlayerStatus, play?: PlayObject, reportedTS?: Dayjs) {
+    update(state: PlayerStateDataMaybePlay, reportedTS?: Dayjs) {
         this.stateLastUpdatedAt = dayjs();
+
+        const {play, status} = state;
+        
         if (play !== undefined) {
             return this.setPlay(play, status, reportedTS);
         } else if (status !== undefined) {

--- a/src/backend/sources/PlayerState/AbstractPlayerState.ts
+++ b/src/backend/sources/PlayerState/AbstractPlayerState.ts
@@ -1,10 +1,12 @@
 import { childLogger, Logger } from "@foxxmd/logging";
 import dayjs, { Dayjs } from "dayjs";
-import { PlayObject, Second, SOURCE_SOT, SOURCE_SOT_TYPES, SourcePlayerObj } from "../../../core/Atomic.js";
+import { PlayObject, PlayProgress, Second, SOURCE_SOT, SOURCE_SOT_TYPES, SourcePlayerObj } from "../../../core/Atomic.js";
 import { buildTrackString } from "../../../core/StringUtils.js";
 import {
+    asPlayerStateData,
     CALCULATED_PLAYER_STATUSES,
     CalculatedPlayerStatus,
+    PlayerStateData,
     PlayerStateDataMaybePlay,
     PlayPlatformId,
     REPORTED_PLAYER_STATUSES,
@@ -13,7 +15,7 @@ import {
 import { PollingOptions } from "../../common/infrastructure/config/common.js";
 import { formatNumber, genGroupIdStr, playObjDataMatch, progressBar } from "../../utils.js";
 import { ListenProgress } from "./ListenProgress.js";
-import { ListenRange } from "./ListenRange.js";
+import { ListenRange, ListenRangePositional } from "./ListenRange.js";
 
 export interface PlayerStateIntervals {
     staleInterval?: number
@@ -21,6 +23,8 @@ export interface PlayerStateIntervals {
 }
 
 export interface PlayerStateOptions extends PlayerStateIntervals {
+    allowedDrift?: number
+    rtTruth?: boolean
 }
 
 export const DefaultPlayerStateOptions: PlayerStateOptions = {};
@@ -58,8 +62,6 @@ export abstract class AbstractPlayerState {
     createdAt: Dayjs = dayjs();
     stateLastUpdatedAt: Dayjs = dayjs();
 
-    protected allowedDrift?: number;
-
     protected constructor(logger: Logger, platformId: PlayPlatformId, opts: PlayerStateOptions = DefaultPlayerStateOptions) {
         this.platformId = platformId;
         this.logger = childLogger(logger, `Player ${this.platformIdStr}`);
@@ -70,6 +72,9 @@ export abstract class AbstractPlayerState {
         } = opts;
         this.stateIntervalOptions = {staleInterval, orphanedInterval: orphanedInterval};
     }
+
+    protected abstract newListenProgress(data?: Partial<PlayProgress>): ListenProgress;
+    protected abstract newListenRange(start?: ListenProgress, end?: ListenProgress, options?: object): ListenRange;
 
     get platformIdStr() {
         return genGroupIdStr(this.platformId);
@@ -126,10 +131,12 @@ export abstract class AbstractPlayerState {
         this.stateLastUpdatedAt = dayjs();
 
         const {play, status} = state;
-        
-        if (play !== undefined) {
-            return this.setPlay(play, status, reportedTS);
-        } else if (status !== undefined) {
+
+        if (asPlayerStateData(state)) {
+            return this.setPlay(state, reportedTS);
+        } 
+
+        if (status !== undefined) {
             if (status === 'stopped' && this.reportedStatus !== 'stopped' && this.currentPlay !== undefined) {
                 this.stopPlayer();
                 const play = this.getPlayedObject(true);
@@ -143,19 +150,19 @@ export abstract class AbstractPlayerState {
         return [];
     }
 
-    protected setPlay(play: PlayObject, status?: ReportedPlayerStatus, reportedTS?: Dayjs): [PlayObject, PlayObject?] {
+    protected setPlay(state: PlayerStateData, reportedTS?: Dayjs): [PlayObject, PlayObject?] {
+        const {play, status} = state;
         this.playLastUpdatedAt = dayjs();
         if (status !== undefined) {
             this.reportedStatus = status;
         }
 
         if (this.currentPlay !== undefined) {
-            const currentPlayMatches = playObjDataMatch(this.currentPlay, play);
-            if (!currentPlayMatches) { // TODO check new play date and listen range to see if they intersect
+            if (!this.incomingPlayMatchesExisting(play)) { // TODO check new play date and listen range to see if they intersect
                 this.logger.debug(`Incoming play state (${buildTrackString(play, {include: ['trackId', 'artist', 'track']})}) does not match existing state, removing existing: ${buildTrackString(this.currentPlay, {include: ['trackId', 'artist', 'track']})}`)
                 this.currentListenSessionEnd();
                 const played = this.getPlayedObject(true);
-                this.setCurrentPlay(play, {reportedTS});
+                this.setCurrentPlay(state, {reportedTS});
                 if (this.calculatedStatus !== CALCULATED_PLAYER_STATUSES.playing) {
                     this.calculatedStatus = CALCULATED_PLAYER_STATUSES.unknown;
                 }
@@ -163,27 +170,30 @@ export abstract class AbstractPlayerState {
             } else if (status !== undefined && !AbstractPlayerState.isProgressStatus(status)) {
                 this.currentListenSessionEnd();
                 this.calculatedStatus = this.reportedStatus;
-            } else if (this.isSessionRepeat(play.meta.trackProgressPosition, reportedTS)) {
+            } else if (this.isSessionRepeat(state.position, reportedTS)) {
                 // if we detect the track has been restarted end listen session and treat as a new play
                 this.currentListenSessionEnd();
                 const played = this.getPlayedObject(true);
                 play.data.playDate = dayjs();
-                this.setCurrentPlay(play, {reportedTS});
+                this.setCurrentPlay(state, {reportedTS});
                 return [this.getPlayedObject(), played];
             } else {
                 if(this.currentListenRange !== undefined) {
-                    const [isSeeked, seekedPos] = this.currentListenRange.seeked(play.meta.trackProgressPosition, reportedTS);
+                    const [isSeeked, seekedPos] = this.currentListenRange.seeked(state.position, reportedTS);
                     if (isSeeked !== false) {
-                        this.logger.debug(`Detected player was seeked ${seekedPos.toFixed(2)}s, starting new listen range`);
+                        this.logger.verbose(`Detected player was seeked ${(seekedPos / 1000).toFixed(2)}s, starting new listen range`);
+                        if(state.position !== undefined && (this.currentListenRange as ListenRangePositional).end.position === state.position) {
+                            this.calculatedStatus = CALCULATED_PLAYER_STATUSES.paused;
+                        }
                         // if player has been seeked start a new listen range so our numbers don't get all screwy
                         this.currentListenSessionEnd();
                     }
                 }
 
-                this.currentListenSessionContinue(play.meta.trackProgressPosition, reportedTS);
+                this.currentListenSessionContinue(state.position, reportedTS);
             }
         } else {
-            this.setCurrentPlay(play);
+            this.setCurrentPlay(state);
             this.calculatedStatus = CALCULATED_PLAYER_STATUSES.unknown;
         }
 
@@ -193,6 +203,8 @@ export abstract class AbstractPlayerState {
 
         return [this.getPlayedObject(), undefined];
     }
+
+    protected incomingPlayMatchesExisting(play: PlayObject): boolean { return playObjDataMatch(this.currentPlay, play); }
 
     protected clearPlayer() {
         this.currentPlay = undefined;
@@ -244,65 +256,9 @@ export abstract class AbstractPlayerState {
         return listenDur;
     }
 
-    protected currentListenSessionContinue(position?: number, timestamp?: Dayjs) {
-        const now = dayjs();
-        if (this.currentListenRange === undefined) {
-            this.logger.debug('Started new Player listen range.');
-            let usedPosition = position;
-            if(this.calculatedStatus === CALCULATED_PLAYER_STATUSES.playing && position !== undefined && position <= 3) {
-                // likely the player has moved to a new track from a previous track (still calculated as playing)
-                // and polling/network delays means we did not catch absolute beginning of track
-                usedPosition = 1;
-            }
-            this.currentListenRange = new ListenRange(new ListenProgress(timestamp, usedPosition), undefined, this.allowedDrift);
-        } else {
-            const oldEndProgress = this.currentListenRange.end;
-            const newEndProgress = new ListenProgress(timestamp, position);
-            if (position !== undefined && oldEndProgress !== undefined) {
-                if (!this.isSessionStillPlaying(position) && !['paused', 'stopped'].includes(this.calculatedStatus)) {
-                        this.calculatedStatus = this.reportedStatus === 'stopped' ? CALCULATED_PLAYER_STATUSES.stopped : CALCULATED_PLAYER_STATUSES.paused;
-                        if (this.reportedStatus !== this.calculatedStatus) {
-                            this.logger.debug(`Reported status '${this.reportedStatus}' but track position has not progressed between two updates. Calculated player status is now ${this.calculatedStatus}`);
-                        } else {
-                            this.logger.debug(`Player position is equal between current -> last update. Updated calculated status to ${this.calculatedStatus}`);
-                        }
-                } else if (position !== oldEndProgress.position && this.calculatedStatus !== 'playing') {
-                    this.calculatedStatus = CALCULATED_PLAYER_STATUSES.playing;
-                    if (this.reportedStatus !== this.calculatedStatus) {
-                        this.logger.debug(`Reported status '${this.reportedStatus}' but track position has progressed between two updates. Calculated player status is now ${this.calculatedStatus}`);
-                    } else {
-                        this.logger.debug(`Player position changed between current -> last update. Updated calculated status to ${this.calculatedStatus}`);
-                    }
-                }
-            } else {
-                this.calculatedStatus = CALCULATED_PLAYER_STATUSES.playing;
-            }
-            this.currentListenRange.setRangeEnd(newEndProgress);
-        }
-    }
+    protected abstract currentListenSessionContinue(position?: number | undefined, timestamp?: Dayjs);
 
-    protected abstract isSessionStillPlaying(position: number): boolean;
-
-    protected currentListenSessionEnd() {
-        if (this.currentListenRange !== undefined && this.currentListenRange.getDuration() !== 0) {
-            this.logger.debug('Ended current Player listen range.')
-            if(this.calculatedStatus === CALCULATED_PLAYER_STATUSES.playing && this.currentListenRange.isPositional() && !this.currentListenRange.isInitial()) {
-                const {
-                    data: {
-                        duration,
-                    } = {}
-                } = this.currentPlay;
-                if(duration !== undefined && (duration - this.currentListenRange.end.position) < 3) {
-                    // likely the track was listened to until it ended
-                    // but polling interval or network delays caused MS to not get data on the very end
-                    // also...within 3 seconds of ending is close enough to call this complete IMO
-                    this.currentListenRange.end.position = duration;
-                }
-            }
-            this.listenRanges.push(this.currentListenRange);
-        }
-        this.currentListenRange = undefined;
-    }
+    protected abstract currentListenSessionEnd();
 
     protected isSessionRepeat(position?: number, reportedTS?: Dayjs) {
         if(this.currentListenRange === undefined) {
@@ -335,11 +291,11 @@ export abstract class AbstractPlayerState {
                 repeatHint = `${repeatHint} and listened to more than 50% (${formatNumber((playerDur/trackDur)*100)}%).`
             }
             if (closeDurNum || closeDurPer) {
-                this.logger.debug(repeatHint);
+                this.logger.verbose(repeatHint);
                 return true;
             }
-            if (trackDur !== undefined) {
-                const lastPos = this.currentListenRange.end.position;
+            if (trackDur !== undefined && this.currentListenRange.getPosition() !== undefined) {
+                const lastPos = this.currentListenRange.getPosition();
                 // or last position is within 10 seconds (or 10%) of end of track
                 const nearEndNum = (trackDur - lastPos < 12);
                 if(nearEndNum) {
@@ -350,7 +306,7 @@ export abstract class AbstractPlayerState {
                     repeatHint = `${repeatHint} and previous position was within 15% of track end (${formatNumber((lastPos/trackDur)*100)}%)`;
                 }
                 if(nearEndNum || nearEndPos) {
-                    this.logger.debug(repeatHint);
+                    this.logger.verbose(repeatHint);
                     return true;
                 }
             }
@@ -358,13 +314,15 @@ export abstract class AbstractPlayerState {
         return false;
     }
 
-    protected setCurrentPlay(play: PlayObject, options?: CurrentPlayOptions) {
+    protected setCurrentPlay(state: PlayerStateData, options?: CurrentPlayOptions) {
 
         const {
             status,
             reportedTS,
             listenSessionManaged = true
         } = options || {};
+
+        const {play, position} = state;
 
         this.currentPlay = play;
         this.playFirstSeenAt = dayjs();
@@ -378,7 +336,7 @@ export abstract class AbstractPlayerState {
         }
 
         if (listenSessionManaged && !['stopped'].includes(this.reportedStatus)) {
-            this.currentListenSessionContinue(play.meta.trackProgressPosition, reportedTS);
+            this.currentListenSessionContinue(position, reportedTS);
         }
     }
 
@@ -390,7 +348,7 @@ export abstract class AbstractPlayerState {
         }
         parts.push(`Reported: ${this.reportedStatus.toUpperCase()} | Calculated: ${this.calculatedStatus.toUpperCase()} | Stale: ${this.isUpdateStale() ? 'Yes' : 'No'} | Orphaned: ${this.isOrphaned() ? 'Yes' : 'No'} | Last Update: ${this.stateLastUpdatedAt.toISOString()}`);
         let progress = '';
-        if (this.currentListenRange !== undefined && this.currentListenRange.end.position !== undefined && this.currentPlay.data.duration !== undefined) {
+        if (this.currentListenRange !== undefined && this.currentListenRange instanceof ListenRangePositional && this.currentPlay.data.duration !== undefined) {
             progress = `${progressBar(this.currentListenRange.end.position / this.currentPlay.data.duration, 1, 15)} ${formatNumber(this.currentListenRange.end.position, {toFixed: 0})}/${formatNumber(this.currentPlay.data.duration, {toFixed: 0})}s | `;
         }
         let listenedPercent = '';
@@ -408,20 +366,17 @@ export abstract class AbstractPlayerState {
         this.logger.debug(this.textSummary());
     }
 
-    public getPosition(): Second {
+    public getPosition(): Second | undefined {
         if(this.calculatedStatus === 'stopped') {
             return undefined;
         }
-        let lastRange: ListenRange | undefined;
         if(this.currentListenRange !== undefined) {
-            lastRange = this.currentListenRange;
-        } else if(this.listenRanges.length > 0) {
-            lastRange = this.listenRanges[this.listenRanges.length - 1];
+            return this.currentListenRange.getPosition();
         }
-        if(lastRange === undefined || lastRange.end === undefined || lastRange.end.position === undefined) {
-            return undefined;
+        if(this.listenRanges.length > 0) {
+            return this.listenRanges[this.listenRanges.length - 1].getPosition();
         }
-        return lastRange.end.position;
+        return undefined;
     }
 
     public getApiState(): SourcePlayerObj {
@@ -446,7 +401,7 @@ export abstract class AbstractPlayerState {
         this.logger.debug(`Transferring state to new Player (${newPlayer.platformIdStr})`);
         newPlayer.calculatedStatus = this.calculatedStatus;
         if(this.currentPlay !== undefined) {
-            newPlayer.setCurrentPlay(this.currentPlay, {status: this.reportedStatus, listenSessionManaged: false});
+            newPlayer.setCurrentPlay({play: this.currentPlay, platformId: this.platformId}, {status: this.reportedStatus, listenSessionManaged: false});
         }
         newPlayer.currentListenRange = this.currentListenRange;
         newPlayer.listenRanges = this.listenRanges;

--- a/src/backend/sources/PlayerState/GenericPlayerState.ts
+++ b/src/backend/sources/PlayerState/GenericPlayerState.ts
@@ -1,13 +1,40 @@
 import { Logger } from "@foxxmd/logging";
-import { PlayPlatformId } from "../../common/infrastructure/Atomic.js";
+import { CALCULATED_PLAYER_STATUSES, PlayPlatformId } from "../../common/infrastructure/Atomic.js";
 import { AbstractPlayerState, PlayerStateOptions } from "./AbstractPlayerState.js";
+import { PlayProgress } from "../../../core/Atomic.js";
+import { ListenProgress, ListenProgressTS } from "./ListenProgress.js";
+import { ListenRange, ListenRangeTS } from "./ListenRange.js";
+import { Dayjs } from "dayjs";
 
 export class GenericPlayerState extends AbstractPlayerState {
+    protected newListenProgress(data?: Partial<PlayProgress>): ListenProgress {
+        return new ListenProgressTS(data);
+    }
+
+    protected newListenRange(start?: ListenProgress, end?: ListenProgress, options?: object): ListenRange {
+        return new ListenRangeTS(start, end);
+    }
+
     constructor(logger: Logger, platformId: PlayPlatformId, opts?: PlayerStateOptions) {
         super(logger, platformId, opts);
     }
+    
+    protected currentListenSessionContinue(position?: number, timestamp?: Dayjs) {
+        if (this.currentListenRange === undefined) {
+            this.logger.debug('Started new Player listen range.');
+            this.currentListenRange = this.newListenRange(this.newListenProgress({timestamp}));
+        } else {
+            this.calculatedStatus = CALCULATED_PLAYER_STATUSES.playing;
+            this.currentListenRange.setRangeEnd(this.newListenProgress({timestamp}));
+        }
+    }
 
-    protected isSessionStillPlaying(position: number): boolean {
-        return position !== this.currentListenRange.end.position;
+    protected currentListenSessionEnd() {
+        if (this.currentListenRange !== undefined && this.currentListenRange.getDuration() !== 0) {
+            this.logger.debug('Ended current Player listen range.')
+            this.currentListenRange.finalize();
+            this.listenRanges.push(this.currentListenRange);
+        }
+        this.currentListenRange = undefined;
     }
 }

--- a/src/backend/sources/PlayerState/JellyfinPlayerState.ts
+++ b/src/backend/sources/PlayerState/JellyfinPlayerState.ts
@@ -3,8 +3,9 @@ import { PlayObject } from "../../../core/Atomic.js";
 import { PlayerStateDataMaybePlay, PlayPlatformId, ReportedPlayerStatus } from "../../common/infrastructure/Atomic.js";
 import { PlayerStateOptions } from "./AbstractPlayerState.js";
 import { GenericPlayerState } from "./GenericPlayerState.js";
+import { PositionalPlayerState } from "./PositionalPlayerState.js";
 
-export class JellyfinPlayerState extends GenericPlayerState {
+export class JellyfinPlayerState extends PositionalPlayerState {
     constructor(logger: Logger, platformId: PlayPlatformId, opts?: PlayerStateOptions) {
         super(logger, platformId, opts);
     }

--- a/src/backend/sources/PlayerState/JellyfinPlayerState.ts
+++ b/src/backend/sources/PlayerState/JellyfinPlayerState.ts
@@ -1,6 +1,6 @@
 import { Logger } from "@foxxmd/logging";
 import { PlayObject } from "../../../core/Atomic.js";
-import { PlayPlatformId, ReportedPlayerStatus } from "../../common/infrastructure/Atomic.js";
+import { PlayerStateDataMaybePlay, PlayPlatformId, ReportedPlayerStatus } from "../../common/infrastructure/Atomic.js";
 import { PlayerStateOptions } from "./AbstractPlayerState.js";
 import { GenericPlayerState } from "./GenericPlayerState.js";
 
@@ -9,11 +9,11 @@ export class JellyfinPlayerState extends GenericPlayerState {
         super(logger, platformId, opts);
     }
 
-    setState(status?: ReportedPlayerStatus, play?: PlayObject) {
-        let stat: ReportedPlayerStatus = status;
-        if(status === undefined && play.meta?.event === 'PlaybackProgress') {
+    update(state: PlayerStateDataMaybePlay) {
+        let stat: ReportedPlayerStatus = state.status;
+        if(stat === undefined && state.play?.meta?.event === 'PlaybackProgress') {
             stat = 'playing';
         }
-        return super.setState(stat, play);
+        return super.update({...state, status: stat});
     }
 }

--- a/src/backend/sources/PlayerState/ListenProgress.ts
+++ b/src/backend/sources/PlayerState/ListenProgress.ts
@@ -1,32 +1,53 @@
 import dayjs, { Dayjs } from "dayjs";
 
-import { PlayProgress, Second } from "../../../core/Atomic.js";
+import { PlayProgress, PlayProgressPositional, Second } from "../../../core/Atomic.js";
 
-export class ListenProgress implements PlayProgress {
+export class ListenProgressTS implements PlayProgress {
 
     public timestamp: Dayjs;
-    public position?: Second;
     public positionPercent?: number;
 
-    constructor(timestamp?: Dayjs, position?: number, positionPercent?: number) {
+    constructor(data: Partial<PlayProgress> = {}) {
+        const {timestamp, positionPercent} = data;
         this.timestamp = timestamp ?? dayjs();
-        this.position = position;
         this.positionPercent = positionPercent;
     }
 
-    getDuration(end: ListenProgress): Second {
-        if (this.position !== undefined && end.position !== undefined) {
-            return end.position - this.position;
-        } else {
-            return end.timestamp.diff(this.timestamp, 'seconds');
-        }
+    getDuration(end: ListenProgressTS): Second {
+        return end.timestamp.diff(this.timestamp, 'seconds');
     }
 
     toJSON() {
         return {
             timestamp: this.timestamp.toISOString(),
-            position: this.position,
+            position: undefined,
             positionPercent: this.positionPercent
         }
     }
 }
+
+export class ListenProgressPositional extends ListenProgressTS implements PlayProgressPositional {
+    public position: Second;
+
+    constructor(data: PlayProgressPositional) {
+        super(data);
+        const {timestamp, position} = data;
+        this.timestamp = timestamp ?? dayjs();
+        this.position = position;
+    }
+
+    getDuration(end: ListenProgressPositional): Second {
+        return end.position - this.position;
+    }
+
+
+    toJSON() {
+        return {
+            timestamp: this.timestamp.toISOString(),
+            position: this.position,
+            positionPercent: undefined
+        }
+    }
+}
+
+export type ListenProgress = ListenProgressTS | ListenProgressPositional;

--- a/src/backend/sources/PlayerState/ListenRange.ts
+++ b/src/backend/sources/PlayerState/ListenRange.ts
@@ -1,69 +1,180 @@
 import dayjs, { Dayjs } from "dayjs";
-import { ListenRangeData, Second } from "../../../core/Atomic.js";
-import { ListenProgress } from "./ListenProgress.js";
+import { ListenRangeData, Millisecond, PlayProgress, PlayProgressPositional, Second } from "../../../core/Atomic.js";
+import { ListenProgress, ListenProgressPositional,  ListenProgressTS } from "./ListenProgress.js";
+import { GenericRealtimePlayer, RealtimePlayer } from "./RealtimePlayer.js";
 
-export class ListenRange implements ListenRangeData {
-
+export abstract class ListenRange {
     public start: ListenProgress;
     public end: ListenProgress;
-    protected allowedDrift: number;
 
-    constructor(start?: ListenProgress, end?: ListenProgress, allowedDrift: number = 2500) {
-        const s = start ?? new ListenProgress();
+    constructor(start?: ListenProgress, end?: ListenProgress) {
+        const s = start ?? new ListenProgressTS();
         const e = end ?? s;
 
         this.start = s;
         this.end = e;
-        this.allowedDrift = allowedDrift;
     }
 
+    public abstract isPositional(): boolean;
+    public abstract isInitial(): boolean;
+    public abstract seeked(position?: number, reportedTS?: Dayjs): [boolean, Second?];
+    public abstract setRangeStart(data: ListenProgress | Partial<PlayProgress>);
+    public abstract setRangeEnd(data: ListenProgress | Partial<PlayProgress>);
+    public abstract getDuration(): Second;
+    public abstract getPosition(): Second | undefined;
+    public abstract finalize(position?: number);
+    public abstract toJSON();
+}
+
+export class ListenRangeTS extends ListenRange implements ListenRangeData {
+
+    declare public start: ListenProgressTS;
+    declare public end: ListenProgressTS;
+
     isPositional() {
-        return this.start.position !== undefined && this.end.position !== undefined;
+        return false;
     }
 
     isInitial() {
-        if (this.isPositional()) {
-            return this.start.position === this.end.position;
-        }
         return this.start.timestamp.isSame(this.end.timestamp);
     }
 
     seeked(position?: number, reportedTS: Dayjs = dayjs()): [boolean, Second?] {
-        if (position === undefined || this.isInitial() || !this.isPositional()) {
-            return [false];
+        return [false];
+    }
+
+    setRangeStart(data: ListenProgress | Partial<PlayProgress>) {
+        if (data instanceof ListenProgressTS) {
+            this.start = data;
+        } else {
+            const d = data || {};
+            this.start = new ListenProgressTS(d)
         }
+    }
+
+    setRangeEnd(data: ListenProgress | Partial<PlayProgress>) {
+        if (data instanceof ListenProgressTS) {
+            this.end = data;
+        } else {
+            const d = data || {};
+            this.end = new ListenProgressTS(d)
+        }
+    }
+
+    getDuration(): Second {
+        return this.start.getDuration(this.end);
+    }
+
+    public getPosition(): Second {
+        return undefined;
+    }
+
+    public finalize(position?: number) {
+    }
+
+    toJSON() {
+        return [this.start, this.end];
+    }
+}
+
+export class ListenRangePositional extends ListenRange {
+
+    declare public start: ListenProgressPositional
+    declare public end: ListenProgressPositional;
+    public rtPlayer: RealtimePlayer;
+    protected finalized: boolean;
+    rtTruth: boolean;
+
+    protected allowedDrift: number;
+
+    constructor(start?: ListenProgressPositional, end?: ListenProgressPositional, options: {rtTruth?: boolean, allowedDrift?: number, rtImmediate?: boolean} = {}) {
+        super(start, end);
+        const { allowedDrift = 2000, rtTruth = false, rtImmediate = true } = options;
+        this.allowedDrift = allowedDrift;
+        this.rtTruth = rtTruth;
+        this.rtPlayer = new GenericRealtimePlayer();
+        this.rtPlayer.setPosition(start.position * 1000);
+        if(rtImmediate) {
+            this.rtPlayer.play();
+        }
+        this.finalized = false;
+    }
+
+    isPositional(): boolean {
+        return true;
+    }
+
+    isInitial() {
+        return this.start.position === this.end.position;
+    }
+
+    seeked(position: Second, reportedTS: Dayjs = dayjs()): [boolean, Millisecond?] {
         // if (new) position is earlier than last stored position then the user has seeked backwards on the player
         if (position < this.end.position) {
-            return [true, position - this.end.position];
+            return [true, (position - this.end.position) * 1000];
         }
 
         // if (new) position is more than a reasonable number of ms ahead of real time than they have seeked forwards on the player
-        const realTimeDiff = Math.max(0, reportedTS.diff(this.end.timestamp, 'ms')); // 0 max used so TS from testing doesn't cause "backward" diff
-        const positionDiff = (position - this.end.position) * 1000;
+        //const realTimeDiff = Math.max(0, reportedTS.diff(this.end.timestamp, 'ms')); // 0 max used so TS from testing doesn't cause "backward" diff
+        //const positionDiff = (position - this.end.position) * 1000;
         // if user is more than 2.5 seconds ahead of real time
-        if (positionDiff - realTimeDiff > this.allowedDrift) {
-            return [true, position - this.end.position];
+        if (this.isOverDrifted(position)) {
+            return [true, this.getDrift(position)];
         }
 
         return [false];
     }
 
-    setRangeStart(data: ListenProgress | { position?: number, timestamp?: Dayjs, positionPercent?: number }) {
-        if (data instanceof ListenProgress) {
+    setRangeStart(data: ListenProgressPositional | PlayProgressPositional) {
+        if (data instanceof ListenProgressPositional) {
             this.start = data;
         } else {
-            const d = data || {};
-            this.start = new ListenProgress(d.timestamp, d.position, d.positionPercent)
+            //const d = data || {};
+            this.start = new ListenProgressPositional(data)
+        }
+        this.rtPlayer.stop();
+        this.rtPlayer.play(this.start.position);
+    }
+
+    getDrift(position?: Second): Millisecond {
+            return ((position ?? this.end.position) * 1000) - this.rtPlayer.getPosition();
+    }
+
+    isOverDrifted(position: Second): boolean {
+        return Math.abs(this.getDrift((position ?? this.end.position))) > this.allowedDrift;
+    }
+
+    setRangeEnd(data: ListenProgressPositional | PlayProgressPositional/* , force?: boolean */) {
+        const endProgress = data instanceof ListenProgressPositional ? data : new ListenProgressPositional(data)
+        // if(this.rtTruth) {
+        //     if(!this.isOverDrifted(endProgress.position) && !force) {
+        //         endProgress.position = this.rtPlayer.getPosition();
+        //     } else {
+        //         // if we've drifted too far sync RT to reported position
+        //         this.rtPlayer.setPosition(endProgress.position);
+        //     }
+        // }
+        this.end = endProgress;
+    }
+
+    finalize(position?: number) {
+        this.rtPlayer.pause();
+        this.finalized = true;
+        let finalPosition = position;
+        if(finalPosition === undefined && this.rtTruth) {
+            finalPosition = this.rtPlayer.getPosition(true);
+        }
+
+        if(finalPosition !== undefined) {
+            this.end.position = finalPosition;
         }
     }
 
-    setRangeEnd(data: ListenProgress | { position?: number, timestamp?: Dayjs, positionPercent?: number }) {
-        if (data instanceof ListenProgress) {
-            this.end = data;
-        } else {
-            const d = data || {};
-            this.end = new ListenProgress(d.timestamp, d.position, d.positionPercent)
+    public getPosition(): Second | undefined {
+        if(this.rtTruth && !this.finalized) {
+            this.rtPlayer.getPosition();
         }
+        return this.end.position;
     }
 
     getDuration(): Second {

--- a/src/backend/sources/PlayerState/PlexPlayerState.ts
+++ b/src/backend/sources/PlayerState/PlexPlayerState.ts
@@ -2,11 +2,12 @@ import { Logger } from "@foxxmd/logging";
 import { PlayPlatformId, REPORTED_PLAYER_STATUSES } from "../../common/infrastructure/Atomic.js";
 import { AbstractPlayerState, PlayerStateOptions } from "./AbstractPlayerState.js";
 import { GenericPlayerState } from "./GenericPlayerState.js";
+import { PositionalPlayerState } from "./PositionalPlayerState.js";
 
-export class PlexPlayerState extends GenericPlayerState {
+export class PlexPlayerState extends PositionalPlayerState {
     constructor(logger: Logger, platformId: PlayPlatformId, opts?: PlayerStateOptions) {
-        super(logger, platformId, opts);
-        this.allowedDrift = 17000;
+        super(logger, platformId, {allowedDrift: 17000, rtTruth: true, ...(opts || {})});
+
     }
 
     protected isSessionStillPlaying(position: number): boolean {

--- a/src/backend/sources/PlayerState/PositionalPlayerState.ts
+++ b/src/backend/sources/PlayerState/PositionalPlayerState.ts
@@ -1,0 +1,114 @@
+import { Logger } from "@foxxmd/logging";
+import { CALCULATED_PLAYER_STATUSES, PlayPlatformId, REPORTED_PLAYER_STATUSES } from "../../common/infrastructure/Atomic.js";
+import { AbstractPlayerState, PlayerStateOptions } from "./AbstractPlayerState.js";
+import { GenericPlayerState } from "./GenericPlayerState.js";
+import { GenericRealtimePlayer, RealtimePlayer } from "./RealtimePlayer.js";
+import { PlayProgress, PlayProgressPositional, Second } from "../../../core/Atomic.js";
+import { Dayjs } from "dayjs";
+import { ListenProgress, ListenProgressPositional } from "./ListenProgress.js";
+import { ListenRange, ListenRangePositional } from "./ListenRange.js";
+
+export class PositionalPlayerState extends AbstractPlayerState {
+
+    protected allowedDrift: number;
+    protected rtTruth: boolean;
+
+    declare currentListenRange?: ListenRangePositional;
+    declare listenRanges: ListenRangePositional[];
+
+    constructor(logger: Logger, platformId: PlayPlatformId, opts?: PlayerStateOptions) {
+        super(logger, platformId, opts);
+        const {
+            allowedDrift = 3000,
+            rtTruth = false,
+        } = opts || {};
+        this.allowedDrift = allowedDrift;
+        this.rtTruth = rtTruth;
+    }
+
+    protected newListenProgress(data?: PlayProgressPositional): ListenProgressPositional {
+       return new ListenProgressPositional(data);
+    }
+    protected newListenRange(start?: ListenProgressPositional, end?: ListenProgressPositional, options: object = {}): ListenRangePositional {
+       return new ListenRangePositional(start, end, {allowedDrift: this.allowedDrift, rtTruth: this.rtTruth, ...options});
+    }
+
+    protected isSessionStillPlaying(position: number): boolean {
+        //return this.reportedStatus === REPORTED_PLAYER_STATUSES.playing;
+        if(!this.currentListenRange.isOverDrifted(position)) {
+            return true;
+        }
+        return position !== this.currentListenRange.end.position;
+    }
+
+    protected currentListenSessionContinue(position: number, timestamp?: Dayjs) {
+        if (this.currentListenRange === undefined) {
+            this.logger.debug('Started new Player listen range.');
+            let usedPosition = position;
+            if (this.calculatedStatus === CALCULATED_PLAYER_STATUSES.playing && position !== undefined && position <= 3) {
+                // likely the player has moved to a new track from a previous track (still calculated as playing)
+                // and polling/network delays means we did not catch absolute beginning of track
+                usedPosition = 1;
+            }
+            this.currentListenRange = this.newListenRange(this.newListenProgress({ timestamp, position: usedPosition }), undefined);
+        } else {
+            const oldEndProgress = this.currentListenRange.end;
+            const newEndProgress = this.newListenProgress({ timestamp, position });
+
+            if (!this.isSessionStillPlaying(position) && !['paused', 'stopped'].includes(this.calculatedStatus)) {
+
+                this.calculatedStatus = this.reportedStatus === 'stopped' ? CALCULATED_PLAYER_STATUSES.stopped : CALCULATED_PLAYER_STATUSES.paused;
+
+                if (this.reportedStatus !== this.calculatedStatus) {
+                    this.logger.debug(`Reported status '${this.reportedStatus}' but track position has not progressed between two updates. Calculated player status is now ${this.calculatedStatus}`);
+                } else {
+                    this.logger.debug(`Player position is equal between current -> last update. Updated calculated status to ${this.calculatedStatus}`);
+                }
+            } else if (position !== oldEndProgress.position && this.calculatedStatus !== 'playing') {
+
+                this.calculatedStatus = CALCULATED_PLAYER_STATUSES.playing;
+
+                if (this.reportedStatus !== this.calculatedStatus) {
+                    this.logger.debug(`Reported status '${this.reportedStatus}' but track position has progressed between two updates. Calculated player status is now ${this.calculatedStatus}`);
+                } else {
+                    this.logger.debug(`Player position changed between current -> last update. Updated calculated status to ${this.calculatedStatus}`);
+                }
+            }
+
+            this.currentListenRange.setRangeEnd(newEndProgress);
+        }
+    }
+
+    protected currentListenSessionEnd() {
+        if (this.currentListenRange !== undefined && this.currentListenRange.getDuration() !== 0) {
+            this.logger.debug('Ended current Player listen range.')
+            let finalPosition: number;
+            if(this.calculatedStatus === CALCULATED_PLAYER_STATUSES.playing && !this.currentListenRange.isInitial()) {
+                const {
+                    data: {
+                        duration,
+                    } = {}
+                } = this.currentPlay;
+                if(duration !== undefined && (duration - this.currentListenRange.end.position) < 3) {
+                    // likely the track was listened to until it ended
+                    // but polling interval or network delays caused MS to not get data on the very end
+                    // also...within 3 seconds of ending is close enough to call this complete IMO
+                    finalPosition = duration;
+                    //this.currentListenRange.end.position = duration;
+
+                }
+            }
+            this.currentListenRange.finalize(finalPosition);
+            this.listenRanges.push(this.currentListenRange);
+        }
+        this.currentListenRange = undefined;
+    }
+
+    public getPosition(): Second | undefined {
+        if(this.calculatedStatus !== 'stopped' && this.currentListenRange !== undefined && this.rtTruth) {
+            return this.currentListenRange.rtPlayer.getPosition(true);
+        }
+        return super.getPosition();
+    }
+
+}

--- a/src/backend/sources/PlayerState/RealtimePlayer.ts
+++ b/src/backend/sources/PlayerState/RealtimePlayer.ts
@@ -3,21 +3,22 @@ import { SimpleIntervalJob, Task, ToadScheduler } from "toad-scheduler";
 
 const RT_TICK = 500;
 
-abstract class RealtimePlayer {
+export abstract class RealtimePlayer {
 
-    logger: Logger;
+    //logger: Logger;
     scheduler: ToadScheduler = new ToadScheduler();
 
     protected position: number = 0;
 
-    protected constructor(logger: Logger) {
-        this.logger = childLogger(logger, `RT`);
+    protected constructor(/* logger: Logger */) {
+        //this.logger = childLogger(logger, `RT`);
         const job = new SimpleIntervalJob({
             milliseconds: RT_TICK,
             runImmediately: true
         }, new Task('updatePos', () => this.position += RT_TICK), { id: 'rt' });
         this.scheduler.addSimpleIntervalJob(job);
         this.scheduler.stop();
+        this.position = 0;
     }
 
     public play(position?: number) {
@@ -40,9 +41,17 @@ abstract class RealtimePlayer {
         this.position = position;
     }
 
-    public getPosition() {
-        return this.position;
+    public getPosition(asSeconds: boolean = false) {
+        return !asSeconds ? this.position : this.position / 1000;
+    }
+
+    public setPosition(time: number) {
+        this.position = time;
     }
 }
 
-export class GenericRealtimePlayer extends RealtimePlayer {}
+export class GenericRealtimePlayer extends RealtimePlayer {
+    constructor(/* logger: Logger */) {
+        super();
+    }
+}

--- a/src/backend/sources/PlayerState/RealtimePlayerState.ts
+++ b/src/backend/sources/PlayerState/RealtimePlayerState.ts
@@ -1,0 +1,44 @@
+import { Logger } from "@foxxmd/logging";
+import { PlayPlatformId, REPORTED_PLAYER_STATUSES } from "../../common/infrastructure/Atomic.js";
+import { AbstractPlayerState, PlayerStateOptions } from "./AbstractPlayerState.js";
+import { GenericPlayerState } from "./GenericPlayerState.js";
+import { GenericRealtimePlayer, RealtimePlayer } from "./RealtimePlayer.js";
+import { Second } from "../../../core/Atomic.js";
+import { Dayjs } from "dayjs";
+
+// export class RealtimePlayerState extends GenericPlayerState {
+
+//     rtPlayer: RealtimePlayer;
+//     //allowedDrift: number;
+
+//     constructor(logger: Logger, platformId: PlayPlatformId, opts?: PlayerStateOptions) {
+//         super(logger, platformId, opts);
+//         this.rtPlayer = new GenericRealtimePlayer(logger);
+//         const {
+//             allowedDrift = 3000
+//         } = opts || {};
+//         this.allowedDrift = 3000;
+//     }
+
+//     protected isSessionStillPlaying(position: number): boolean {
+//         return this.reportedStatus === REPORTED_PLAYER_STATUSES.playing;
+//     }
+
+//     public getPosition(): Second | undefined {
+//         if(this.calculatedStatus === 'stopped') {
+//             return undefined;
+//         }
+//         return this.rtPlayer.getPosition();
+//     }
+
+//     protected currentListenSessionEnd() {
+//         super.currentListenSessionEnd();
+//         this.rtPlayer.pause();
+//     }
+//     protected currentListenSessionContinue(position?: number, timestamp?: Dayjs) {
+//         const rt = this.rtPlayer.getPosition(true);
+//             if(Math.abs(position - rt) > this.allowedDrift) {
+//                 this.logger.debug(`Reported position (${position}s) has drifted from real-time (${rt}s) more than allowed (${this.allowedDrift}ms)`);
+//             }
+//     }
+// }

--- a/src/backend/sources/PlexApiSource.ts
+++ b/src/backend/sources/PlexApiSource.ts
@@ -11,7 +11,6 @@ import {
 } from "../common/infrastructure/Atomic.js";
 import { combinePartsToString, genGroupIdStr, getFirstNonEmptyString, getPlatformIdFromData, joinedUrl, parseBool, } from "../utils.js";
 import { parseArrayFromMaybeString } from "../utils/StringUtils.js";
-import MemorySource from "./MemorySource.js";
 import { GetSessionsMetadata } from "@lukehagar/plexjs/sdk/models/operations/getsessions.js";
 import { PlexAPI } from "@lukehagar/plexjs";
 import {
@@ -26,12 +25,13 @@ import { Readable } from 'node:stream';
 import { PlexPlayerState } from './PlayerState/PlexPlayerState.js';
 import { PlayerStateOptions } from './PlayerState/AbstractPlayerState.js';
 import { Logger } from '@foxxmd/logging';
+import { MemoryPositionalSource } from './MemoryPositionalSource.js';
 
 const shortDeviceId = truncateStringToLength(10, '');
 
 const THUMB_REGEX = new RegExp(/\/library\/metadata\/(?<ratingkey>\d+)\/thumb\/\d+/)
 
-export default class PlexApiSource extends MemorySource {
+export default class PlexApiSource extends MemoryPositionalSource {
     users: string[] = [];
 
     plexApi: PlexAPI;

--- a/src/backend/sources/SpotifySource.ts
+++ b/src/backend/sources/SpotifySource.ts
@@ -28,20 +28,20 @@ import {
 } from "../utils.js";
 import { findCauseByFunc } from "../utils/ErrorUtils.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
 import AlbumObjectSimplified = SpotifyApi.AlbumObjectSimplified;
 import ArtistObjectSimplified = SpotifyApi.ArtistObjectSimplified;
 import CurrentlyPlayingObject = SpotifyApi.CurrentlyPlayingObject;
 import PlayHistoryObject = SpotifyApi.PlayHistoryObject;
 import TrackObjectFull = SpotifyApi.TrackObjectFull;
 import UserDevice = SpotifyApi.UserDevice;
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
 const scopes = ['user-read-recently-played', 'user-read-currently-playing', 'user-read-playback-state', 'user-read-playback-position'];
 const state = 'random';
 
 const shortDeviceId = truncateStringToLength(10, '');
 
-export default class SpotifySource extends MemorySource {
+export default class SpotifySource extends MemoryPositionalSource {
 
     spotifyApi: SpotifyWebApi;
     workingCredsPath: string;

--- a/src/backend/sources/VLCSource.ts
+++ b/src/backend/sources/VLCSource.ts
@@ -15,7 +15,7 @@ import { VlcAudioMeta, VLCSourceConfig, PlayerState } from "../common/infrastruc
 import { isPortReachable } from "../utils/NetworkUtils.js";
 import { firstNonEmptyStr } from "../utils/StringUtils.js";
 import { RecentlyPlayedOptions } from "./AbstractSource.js";
-import MemorySource from "./MemorySource.js";
+import { MemoryPositionalSource } from "./MemoryPositionalSource.js";
 
 const CLIENT_PLAYER_STATE: Record<PlayerState, ReportedPlayerStatus> = {
     'playing': REPORTED_PLAYER_STATUSES.playing,
@@ -23,7 +23,7 @@ const CLIENT_PLAYER_STATE: Record<PlayerState, ReportedPlayerStatus> = {
     'stopped': REPORTED_PLAYER_STATUSES.stopped,
 }
 
-export class VLCSource extends MemorySource {
+export class VLCSource extends MemoryPositionalSource {
     declare config: VLCSourceConfig;
 
     host?: string

--- a/src/client/components/player/Player.tsx
+++ b/src/client/components/player/Player.tsx
@@ -94,7 +94,7 @@ art = {},
                         <p className="subtitle">{calculated !== 'stopped' ? artists.join(' / ') : '-'}</p>
                     </div>
 
-                    <PlayerTimestamp duration={duration} current={data.position || 0} />
+                    <PlayerTimestamp duration={duration} indeterminate={calculated === 'playing' && data.position === undefined} current={data.position || 0} />
                     <div className="flex">
                         <p className="stats flex-1 text-left">Status: {capitalize(calculated)}</p>
                         <p className="stats flex-1 text-right">Listened: {calculated !== 'stopped' ? `${listenedDuration.toFixed(0)}s` : '-'}{durPer}</p>

--- a/src/client/components/player/PlayerTimestamp.tsx
+++ b/src/client/components/player/PlayerTimestamp.tsx
@@ -4,6 +4,7 @@ import './timestamp.scss';
 export interface TimestampProps {
     current: number
     duration: number
+    indeterminate?: boolean
 }
 
 const convertTime = (rawTime: number) => {
@@ -19,11 +20,11 @@ const convertTime = (rawTime: number) => {
 const Timestamp = (props: TimestampProps) => {
     return(
         <div className="timestamp">
-            <div className="timestamp__current">
-                {convertTime(Math.floor(props.current))}
+            <div className="timestamp__current" style={{left: props.indeterminate ? '1em' : '0'}}>
+                {props.indeterminate ? '-' : convertTime(Math.floor(props.current))}
             </div>
             <div className="timestamp__progress">
-                <div style={{ width: (props.current === 0 && props.duration === 0 ? 0 : Math.floor((props.current / props.duration) * 100)) + "%" }}></div>
+                <div className={props.indeterminate ? 'indeterminate' : ''} style={{ width: props.indeterminate ? '100%' : (props.current === 0 && props.duration === 0 ? 0 : Math.floor((props.current / props.duration) * 100)) + "%" }}></div>
             </div>
             <div className="timestamp__total">
                 {convertTime(Math.floor(props.duration) - Math.floor(props.current))}
@@ -31,32 +32,5 @@ const Timestamp = (props: TimestampProps) => {
         </div>
     );
 }
-/*export class TimestampC extends React.Component {
-    convertTime(time) {
-        let mins = Math.floor(time / 60);
-        let seconds = time - (mins * 60);
-        if (seconds < 10) {
-            seconds = "0" + seconds;
-        }
-        time = mins + ":" + seconds;
-        return time;
-    }
-
-    render() {
-        return(
-            <div className="timestamp">
-                <div className="timestamp__current">
-                    {this.convertTime(this.props.current)}
-                </div>
-                <div className="timestamp__progress">
-                    <div style={{ width: Math.floor((this.props.current / this.props.duration) * 100) + "%" }}></div>
-                </div>
-                <div className="timestamp__total">
-                    {this.convertTime(this.props.duration - this.props.current)}
-                </div>
-            </div>
-        );
-    }
-}*/
 
 export default Timestamp;

--- a/src/client/components/player/timestamp.scss
+++ b/src/client/components/player/timestamp.scss
@@ -34,6 +34,13 @@ $primary: #556a77;
       bottom: 0;
       background: $primary;
     }
+
+    > div.indeterminate {
+      background-color: #ECEFF1;
+      animation: indeterminateAnimation 3s infinite linear;
+      transform-origin: 0% 50%;
+      background: $primary;
+    }
   }
 
   &__current {
@@ -42,5 +49,17 @@ $primary: #556a77;
 
   &__total {
     right: 0;
+  }
+}
+
+@keyframes indeterminateAnimation {
+  0% {
+    transform:  translateX(0) scaleX(0);
+  }
+  50% {
+    transform:  translateX(0) scaleX(0.5);
+  }
+  100% {
+    transform:  translateX(100%) scaleX(0.5);
   }
 }

--- a/src/core/Atomic.ts
+++ b/src/core/Atomic.ts
@@ -168,6 +168,10 @@ export interface AmbPlayObject {
     meta: PlayMeta
 }
 
+export const isPlayObject = (obj: object): obj is PlayObject => {
+   return 'data' in obj && typeof obj.data === 'object' && 'meta' in obj && typeof obj.meta === 'object';
+}
+
 export interface PlayObject extends AmbPlayObject {
     data: ObjectPlayData,
 }

--- a/src/core/Atomic.ts
+++ b/src/core/Atomic.ts
@@ -54,6 +54,10 @@ export interface PlayProgress {
     positionPercent?: number
 }
 
+export interface PlayProgressPositional extends PlayProgress {
+    position: number
+}
+
 export interface ListenRangeData {
     start: ListenProgress
     end: ListenProgress


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Describe your changes

* Introduce positional and non-positional data structures
  * Refactor state player into types of each
  * Refactor listen ranges and progress into types of each
* Implment (internal) real-time player and base positional player seeked/repeat on real-time drift instead of only reported position
* Refactor tests to use (emulated) real-time components

While this is a large fundamental restructure it (should) only functionally affect Plex API Source as it makes it more accurate since we don't rely solely on reported position for calculated state and listening range.

On the dev side it makes player state logic much clearer as there are way few if-else blocks just checking for `position === undefined`.
