### PR TITLE
refactor: bubble init usage and errors to simplify recovery

### DIFF
--- a/src/backend/common/errors/MSErrors.ts
+++ b/src/backend/common/errors/MSErrors.ts
@@ -1,0 +1,25 @@
+export abstract class NamedError extends Error {
+    public abstract name: string;
+}
+
+export abstract class StageError extends NamedError {}
+
+export class BuildDataError extends StageError {
+    name = 'Init Build Data';
+}
+
+export class TransformRulesError extends StageError {
+    name = 'Transform Rules';
+}
+
+export class ConnectionCheckError extends StageError {
+    name = 'Conenction Check';
+}
+
+export class AuthCheckError extends StageError {
+    name = 'Authentication Check';
+}
+
+export class PostInitError extends StageError {
+    name = 'Post Initialization';
+}

--- a/src/backend/common/vendor/JRiverApiClient.ts
+++ b/src/backend/common/vendor/JRiverApiClient.ts
@@ -151,8 +151,7 @@ export class JRiverApiClient extends AbstractApiClient {
             if(this.config.username === undefined || this.config.password === undefined) {
                 msg = 'Authentication failed. No username/password was provided in config! Did you mean to do this?';
             }
-            this.logger.error(new Error(msg, {cause: e}));
-            return false;
+            throw new Error(msg, {cause: e});
         }
     }
 

--- a/src/backend/common/vendor/KodiApiClient.ts
+++ b/src/backend/common/vendor/KodiApiClient.ts
@@ -142,8 +142,7 @@ export class KodiApiClient extends AbstractApiClient {
             if(this.config.username === undefined || this.config.password === undefined) {
                 msg = 'Authentication failed. No username/password was provided in config! Did you mean to do this?';
             }
-            this.logger.error(new Error(msg, {cause: e}));
-            return false;
+            throw new Error(msg, {cause: e});
         }
     }
 

--- a/src/backend/scrobblers/AbstractScrobbleClient.ts
+++ b/src/backend/scrobblers/AbstractScrobbleClient.ts
@@ -149,7 +149,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
     }
 
     protected notify = async (payload: WebhookPayload) => {
-        this.notify(payload);
+        this.emitEvent('notify', payload);
     }
 
     protected async postInitialize(): Promise<void> {

--- a/src/backend/scrobblers/MalojaScrobbler.ts
+++ b/src/backend/scrobblers/MalojaScrobbler.ts
@@ -276,12 +276,12 @@ export default class MalojaScrobbler extends AbstractScrobbleClient {
                 this.logger.info('Auth test passed!');
                 return true;
             } else {
-                this.logger.error('Testing connection failed => Server Response body was malformed -- should have returned "status: ok"...is the URL correct?', {
+                this.logger.error('Maloja API Response', {
                     status,
                     body,
                     text: text.slice(0, 50)
                 });
-                return false;
+                throw new Error('Server Response body was malformed -- should have returned "status: ok"...is the URL correct?', {cause: new Error(`Maloja API Response was ${status}: ${text.slice(0,50)}`)})
             }
         } catch (e) {
             if(e instanceof UpstreamError) {

--- a/src/backend/sources/DeezerSource.ts
+++ b/src/backend/sources/DeezerSource.ts
@@ -126,8 +126,7 @@ export default class DeezerSource extends AbstractSource {
 
     doAuthentication = async () => {
         if(this.config.data.accessToken === undefined) {
-            this.logger.warn(`No access token is present. User interaction for authentication is required.`);
-            return false;
+            throw new Error(`No access token is present. User interaction for authentication is required.`);
         }
         try {
             await this.callApi(request.get(`${this.baseUrl}/user/me`));

--- a/src/backend/sources/JRiverSource.ts
+++ b/src/backend/sources/JRiverSource.ts
@@ -72,9 +72,13 @@ export class JRiverSource extends MemoryPositionalSource {
     }
 
     doAuthentication = async () => {
-        const resp = await this.client.testAuth();
-        this.clientReady = resp;
-        return resp;
+        try {
+            const resp = await this.client.testAuth();
+            this.clientReady = true;
+            return true;
+        } catch (e) {
+            throw e;
+        }
     }
 
     static formatPlayObj(obj: Info, options: FormatPlayObjectOptions = {}): PlayObject {

--- a/src/backend/sources/KodiSource.ts
+++ b/src/backend/sources/KodiSource.ts
@@ -38,9 +38,13 @@ export class KodiSource extends MemoryPositionalSource {
     }
 
     doAuthentication = async () => {
-        const resp = await this.client.testAuth();
-        this.clientReady = resp;
-        return resp;
+        try {
+            const resp = await this.client.testAuth();
+            this.clientReady = true;
+            return true;
+        } catch (e) {
+            throw e;
+        }
     }
 
     static formatPlayObj(obj: any, options: FormatPlayObjectOptions = {}): PlayObject {

--- a/src/backend/tasks/heartbeatSources.ts
+++ b/src/backend/tasks/heartbeatSources.ts
@@ -15,22 +15,40 @@ export const createHeartbeatSourcesTask = (sources: ScrobbleSources, parentLogge
                 .withConcurrency(1)
                 .for(sources.sources)
                 .process(async (source) => {
-                    if(source.isReady()) {
-                        if(source.type === 'chromecast') {
-                            (source as ChromecastSource).discoverDevices();
+                    if(!source.isReady()) {
+                        if(!source.canAuthUnattended()) {
+                            source.logger.warn({label: 'Heartbeat'}, 'Source is not ready but will not try to initialize because auth state is not good and cannot be correct unattended.');
+                            return 0;
                         }
-                        if (source.canPoll && !source.polling && (!source.authGated() || source.canTryAuth())) {
-                            source.logger.info('Should be polling! Attempting to restart polling...', {leaf: 'Heartbeat'});
-                            source.poll().catch(e => logger.error(e));
+                        try {
+                            await source.tryInitialize({force: false, notify: true, notifyTitle: 'Could not initialize automatically'});
+                        } catch (e) {
+                            source.logger.error(new Error('Could not initialize source automatically', {cause: e}));
                             return 1;
                         }
                     }
+
+                    if(source.type === 'chromecast') {
+                        (source as ChromecastSource).discoverDevices();
+                    }
+
+                    if (source.canPoll && !source.polling) {
+                        if(!source.canAuthUnattended()) {
+                            source.logger.warn({label: 'Heartbeat'}, 'Should be polling but will not attempt to start because auth state is not good and cannot be correct unattended.');
+                            return 0;
+                        } else {
+                            source.logger.info({label: 'Heartbeat'}, 'Should be polling, attempting to start polling...');
+                            source.poll({force: false, notify: true}).catch(e => source.logger.error(e));
+                        }
+                        return 1;
+                    }
+
                     return 0;
                 }).then(({results, errors}) => {
-                    logger.verbose(`Checked ${sources.sources.length} sources for restart signals.`);
+                    logger.verbose(`Checked ${sources.sources.length} sources for start signals.`);
                     const restarted = results.reduce((acc, curr) => acc += curr, 0);
                     if (restarted > 0) {
-                        logger.info(`Attempted to restart ${restarted} sources that were not polling.`);
+                        logger.info(`Attempted to start ${restarted} sources.`);
                     }
                     if (errors.length > 0) {
                         logger.error(`Encountered errors!`);

--- a/src/backend/tests/component/component.test.ts
+++ b/src/backend/tests/component/component.test.ts
@@ -7,10 +7,17 @@ import { TRANSFORM_HOOK } from "../../common/infrastructure/Atomic.js";
 
 import { isConditionalSearchAndReplace } from "../../utils/PlayTransformUtils.js";
 import { asPlays, generatePlay, normalizePlays } from "../utils/PlayTestUtils.js";
+import { WebhookPayload } from "../../common/infrastructure/config/health/webhooks.js";
 
 chai.use(asPromised);
 
 class TestComponent extends AbstractComponent {
+    public notify(payload: WebhookPayload): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    protected getIdentifier(): string {
+        return 'test';
+    }
     constructor() {
         super({});
     }

--- a/src/backend/tests/scrobbler/scrobblers.test.ts
+++ b/src/backend/tests/scrobbler/scrobblers.test.ts
@@ -72,7 +72,11 @@ describe('Networking', function () {
                 ],
                 async function() {
                     const authScrobbler = new TestAuthScrobbler();
-                    await authScrobbler.testAuth();
+                    try {
+                        await authScrobbler.testAuth();
+                    } catch (e) {
+
+                    }
                     assert.isTrue(authScrobbler.authGated());
                     assert.isFalse(authScrobbler.authFailure);
                 }
@@ -88,7 +92,11 @@ describe('Networking', function () {
                 ],
                 async function() {
                     const authScrobbler = new TestAuthScrobbler();
-                    await authScrobbler.testAuth();
+                    try {
+                        await authScrobbler.testAuth();
+                    } catch (e) {
+
+                    }
                     assert.isTrue(authScrobbler.authGated());
                     assert.isTrue(authScrobbler.authFailure);
                 }

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -667,3 +667,27 @@ export const getFirstNonEmptyVal = <T = unknown>(values: unknown[], options: {of
 }
 
 export const getFirstNonEmptyString = (values: unknown[]) => getFirstNonEmptyVal<string>(values, {ofType: 'string', test: (v) => v.trim() !== ''});
+
+  /**
+ * Runs the function `fn`
+ * and retries automatically if it fails.
+ *
+ * Tries max `1 + retries` times
+ * with `retryIntervalMs` milliseconds between retries.
+ *
+ * From https://mtsknn.fi/blog/js-retry-on-fail/
+ */
+export const retry = async <T>(
+    fn: () => Promise<T> | T,
+    { retries, retryIntervalMs }: { retries: number; retryIntervalMs: number }
+  ): Promise<T> => {
+    try {
+      return await fn()
+    } catch (error) {
+      if (retries <= 0) {
+        throw error
+      }
+      await sleep(retryIntervalMs)
+      return retry(fn, { retries: retries - 1, retryIntervalMs })
+    }
+  }

--- a/src/backend/utils/ErrorUtils.ts
+++ b/src/backend/utils/ErrorUtils.ts
@@ -87,7 +87,7 @@ const _messageWithCauses = (err: Error, seen = new Set<Error>()) => {
 
     // Ensure we don't go circular or crazily deep
     if (seen.has(err)) {
-        return message + ': ...';
+        return message + ' => ...';
     }
 
     const cause = getErrorCause(err);
@@ -95,7 +95,7 @@ const _messageWithCauses = (err: Error, seen = new Set<Error>()) => {
     if (cause) {
         seen.add(err);
 
-        return (message + ': ' +
+        return (message + ' => ' +
             _messageWithCauses(cause, seen));
     } else {
         return message;

--- a/src/backend/utils/ErrorUtils.ts
+++ b/src/backend/utils/ErrorUtils.ts
@@ -1,3 +1,5 @@
+import { truncateStringToLength } from "../../core/StringUtils.js";
+
 /**
  * Adapted from https://github.com/voxpelli/pony-cause/blob/main/lib/helpers.js to find cause by truthy function
  * */
@@ -77,17 +79,20 @@ export const findCauseByReference = <T extends Error>(err: unknown, reference: n
         currentErr = getErrorCause(currentErr);
     }
 };
+
+export type MessageTransformer = (val: string) => string;
+export const MessageTransformerDefault = (val: string) => val;
 /**
  * Adapted from https://github.com/voxpelli/pony-cause
  * */
-const _messageWithCauses = (err: Error, seen = new Set<Error>()) => {
+const _messageWithCauses = (err: Error, seen = new Set<Error>(), msgTransform: MessageTransformer = MessageTransformerDefault) => {
     if (!(err instanceof Error)) return '';
 
     const message = err.message;
 
     // Ensure we don't go circular or crazily deep
     if (seen.has(err)) {
-        return message + ' => ...';
+        return msgTransform(message) + ' => ...';
     }
 
     const cause = getErrorCause(err);
@@ -95,13 +100,20 @@ const _messageWithCauses = (err: Error, seen = new Set<Error>()) => {
     if (cause) {
         seen.add(err);
 
-        return (message + ' => ' +
+        return (msgTransform(message) + ' => ' +
             _messageWithCauses(cause, seen));
     } else {
-        return message;
+        return msgTransform(message);
     }
 };
 /**
  * Adapted from https://github.com/voxpelli/pony-cause
  * */
-export const messageWithCauses = (err: Error) => _messageWithCauses(err);
+export const messageWithCauses = (err: Error, msgTransformer?: MessageTransformer) => _messageWithCauses(err, new Set<Error>(), msgTransformer);
+
+export const messageWithCausesTruncated = (length: number) => {
+    const t = truncateStringToLength(length);
+    return (err: Error) => messageWithCauses(err, t);
+}
+
+export const messageWithCausesTruncatedDefault = messageWithCausesTruncated(100);

--- a/src/client/components/statusCard/ClientStatusCard.tsx
+++ b/src/client/components/statusCard/ClientStatusCard.tsx
@@ -40,11 +40,15 @@ const ClientStatusCard = (props: ClientStatusCardData) => {
 
     const [startClientPut, startResult] = useStartClientMutation();
 
-    const tryStart = useCallback((name: string) => startClientPut({name}), [startClientPut]);
+    const tryStart = useCallback((name: string, force?: boolean) => startClientPut({name, force}), [startClientPut]);
 
     let header: string | undefined = display;
     let body = <SkeletonParagraph/>;
-    const startClientElement = <div onClick={()  => tryStart(name)} className="capitalize underline cursor-pointer">{status === 'Running' ? 'Restart' : 'Start'}</div>
+    const startClientElement = (
+        <Fragment>
+    <div onClick={()  => tryStart(name)} className="capitalize underline cursor-pointer inline mr-1">{status === 'Running' ? 'Restart' : 'Start'}</div>
+    (<div onClick={()  => tryStart(name, true)} className="capitalize underline cursor-pointer inline">Force</div>)
+    </Fragment>)
     if(data !== undefined) {
         const {
             hasAuth,

--- a/src/client/components/statusCard/SourceStatusCard.tsx
+++ b/src/client/components/statusCard/SourceStatusCard.tsx
@@ -41,15 +41,8 @@ const SourceStatusCard = (props: SourceStatusCardData) => {
     const [startPut, startResult] = useStartSourceMutation();
 
     const tryStart = useCallback((name: string, type: string, force?: boolean) => startPut({name, type, force}), [startPut]);
+    let startSourceElement = null;
 
-    let startSourceElement = (<Fragment>
-        <div onClick={() => tryStart(name, type)} 
-        className="capitalize underline cursor-pointer inline mr-1">{status === 'Polling' ? 'Restart' : 'Start'}
-        </div>
-        (<div onClick={() => tryStart(name, type, true)} 
-        className="capitalize underline cursor-pointer inline">Force
-        </div>)
-    </Fragment>);
     if(data !== undefined)
     {
         const {
@@ -69,6 +62,22 @@ const SourceStatusCard = (props: SourceStatusCardData) => {
         if(type === 'listenbrainz' || type === 'lastfm') {
             header = `${display} (Source)`;
         }
+
+        let startText = '';
+        if(canPoll) {
+            startText = status === 'Polling' ? 'Restart' : 'Start'
+        } else {
+            startText = status === 'Running' ? 'Reinit' : 'Init'
+        }
+
+        startSourceElement = (<Fragment>
+            <div onClick={() => tryStart(name, type)} 
+            className="capitalize underline cursor-pointer inline mr-1">{startText}
+            </div>
+            (<div onClick={() => tryStart(name, type, true)} 
+            className="capitalize underline cursor-pointer inline">Force
+            </div>)
+        </Fragment>);
 
         const platformIds = Object.keys(players);
 

--- a/src/client/components/statusCard/StatusCardSkeleton.tsx
+++ b/src/client/components/statusCard/StatusCardSkeleton.tsx
@@ -37,8 +37,8 @@ const StatusCardSkeleton = (props: PropsWithChildren<StatusCardSkeletonData>) =>
                         {subtitle ? <div className="text-sm">{subtitle}</div> : null}
                     </div>
                     <div className="text-right">
-                        <div className="flex items-center text-right">{status}<StatusIndicator type={statusType}/></div>
-                        {subtitleRight ? <div className="text-sm">{subtitleRight}</div> : null}
+                        <div className="flex items-center justify-end">{status}<StatusIndicator type={statusType}/></div>
+                        {subtitleRight ? <div className="text-sm justify-end">{subtitleRight}</div> : null}
                     </div>
                 </div>
             </div>

--- a/src/client/components/statusCard/sourceDucks.ts
+++ b/src/client/components/statusCard/sourceDucks.ts
@@ -1,18 +1,20 @@
 import {createApi, fetchBaseQuery} from "@reduxjs/toolkit/dist/query/react";
 
-export const scrobblerApi = createApi({
-    reducerPath: 'scrobblerApi',
+export const sourceApi = createApi({
+    reducerPath: 'sourceApi',
     baseQuery: fetchBaseQuery({baseUrl: '/api/'}),
     endpoints: (builder) => ({
-        startClient: builder.mutation<undefined, {
+        startSource: builder.mutation<undefined, {
             name: string,
+            type: string,
             force?: boolean
         }>({
             query: (params) => ({
-                url: '/client/init',
+                url: '/source/init',
                 method: 'POST',
                 params: {
                     name: params.name,
+                    type: params.type,
                     force: params.force
                 }
             })
@@ -20,4 +22,4 @@ export const scrobblerApi = createApi({
     })
 });
 
-export const {useStartClientMutation} = scrobblerApi;
+export const {useStartSourceMutation} = sourceApi;

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 // Or from '@reduxjs/toolkit/query/react'
 import { setupListeners } from '@reduxjs/toolkit/query'
 import { scrobblerApi } from './components/statusCard/clientDucks';
+import { sourceApi } from './components/statusCard/sourceDucks';
 import { deadApi, deadSlice } from "./deadLetter/deadLetterDucks";
 import { logsReducer } from "./logs/logDucks";
 import { logsApi } from "./logs/logsApi";
@@ -20,6 +21,7 @@ export const store = configureStore({
         [deadApi.reducerPath]: deadApi.reducer,
         [scrobbledApi.reducerPath]: scrobbledApi.reducer,
         [scrobblerApi.reducerPath]: scrobblerApi.reducer,
+        [sourceApi.reducerPath]: sourceApi.reducer,
         [versionApi.reducerPath]: versionApi.reducer,
         //parts: statusReducer
         clients: clientSlice.reducer,
@@ -30,7 +32,7 @@ export const store = configureStore({
     // Adding the api middleware enables caching, invalidation, polling,
     // and other useful features of `rtk-query`.
     middleware: (getDefaultMiddleware) =>
-        getDefaultMiddleware().concat([statusApi.middleware, logsApi.middleware, recentApi.middleware, scrobbledApi.middleware, deadApi.middleware, scrobblerApi.middleware, versionApi.middleware]),
+        getDefaultMiddleware().concat([statusApi.middleware, logsApi.middleware, recentApi.middleware, scrobbledApi.middleware, deadApi.middleware, scrobblerApi.middleware, sourceApi.middleware, versionApi.middleware]),
 })
 
 // optional, but required for refetchOnFocus/refetchOnReconnect behaviors


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Describe your changes

Need to refactor how `initialize()` is used so that is bubbles errors instead of just logging them. This way we can use the actual error reasons for `notify` or when user invokes API to show reasons for component not being able to recover. Needs work:

- [x] Throw error from init and refactor all usage to try-catch OR introduce `initAndLog` as convenience method
- [x] Refactor api usage to enable `force` init when things aren't working as planned and user wants to force a full recovery
- [x] Refactor `notify` usage to pull error causes and consolidate where these happen
- [x] Refactor remaining uses of `testAuth` to try-catch
- [x] Maybe introduce child `Error` classes for init steps to make extracting the desired error `cause` easier?
- [x] Implement or refactor `poll` endpoints so allow re-initializing non-polling components as well

## Issue number and link, if applicable

#220
#231