### PR TITLE
feat(ytm): Re-implement auth with cookie and oauth

### DIFF
--- a/config/ytmusic.json.example
+++ b/config/ytmusic.json.example
@@ -4,6 +4,16 @@
     "enable": true,
     "clients": [],
     "data": {
+      "cookie": "__Secure-1PSIDTS=sidts-CjEB3EgAEvCd-......",
+      // either cookie or id/secret needs to be provided
+      "clientId": "891098404....apps.googleusercontent.com",
+      "clientSecret": "GOCS..."
+
+      // optional
+      //"redirectUri": "http://my.custom.tld/api/ytmusic/callback?name=MyYTMusic"
+    },
+    "options": {
+      "logDiff": true
     }
   }
 ]

--- a/docsite/docs/configuration/configuration.mdx
+++ b/docsite/docs/configuration/configuration.mdx
@@ -721,30 +721,166 @@ After starting multi-scrobbler with credentials in-place open the dashboard (`ht
 
 ### [Youtube Music](https://music.youtube.com)
 
-<details>
+:::warning
 
-    <summary>Migrating from YT Music cookie-based Source</summary>
-
-    In multi-scrobbler **below v0.9.0** YT Music credentials were extracted from browser cookies. Due to authentication inconsistency and YT service changes this was approach was dropped in favor of [oauth authentication which is more stable.](https://ytjs.dev/guide/authentication.html#youtube-tv-oauth2)
-
-    Your existing credentials cannot be migrated. However, the oauth approach is quite easy. Continue following the directions below to setup new authentication for your YT Music Source.
-
-</details>
-
-:::note
-
-* Communication to YT Music is **unofficial** and not supported or endorsed by Google. This means that **this integration may stop working at any time** if Google decides to change how YT Music works in the browser.
+* Communication with YT Music is **unofficial** and not supported or endorsed by Google. This means that **this integration may stop working at any time** if Google decides to change how YT Music works in the browser.
   * Due to this scrobble history from YTM is often inconsistent and can cause missed scrobbles. [See the FAQ](../FAQ.md#youtube-music-misses-scrobbles) for a more detailed explanation.
 
 :::
 
-To authenticate simply start multi-scrobbler with an empty YT Music configuration. An authentication URL/code will be logged in additon to being available from the dashboard.
+#### Authentication
 
-```
-[2024-10-09 15:24:17.358 -0400] INFO   : [App] [Sources] [Ytmusic - MyYTM] ERROR: Sign in with the code 'CLV-KFA-BVKY' using the authentication link on the dashboard or https://www.google.com/device
-```
+Only one of these methods needs to be used. **Cookies** are easier but **OAuth Client**  may be more stable.
 
-Visit the authentication URL and enter the code that was provided (also available on the dashboard). After completing the setup flow MS will log `Auth success` and the YT Music dashboard card will display as **Idle** after refreshing. Click the **Start** link to begin monitoring.
+<Tabs groupId="ytmAuth" queryString>
+    <TabItem value="cookie" label="Cookies">
+        :::info
+
+        If cookies stop working for you or are being invalidated often try switching to **OAuth Client** authentication.
+
+        :::
+
+        Use instructions from 
+        
+        * https://github.com/patrickkfkan/Volumio-YouTube.js/wiki/How-to-obtain-Cookie or 
+        * https://ytmusicapi.readthedocs.io/en/stable/setup/browser.html#copy-authentication-headers 
+        
+        to get the **Cookie** value from a browser.
+
+        It is highly recommended to [get the cookie from an Incognito/Private Session](https://github.com/LuanRT/YouTube.js/issues/803#issuecomment-2504032666) to limit the chance the session is invalidated from normal browsing.
+
+        Add the cookie to your `ytmusic.json` config in `data`: 
+
+        ```json
+            {
+            "type": "ytmusic",
+            "enable": true,
+            "name": "MyYTM",
+            "data": {
+                "cookie": "__Secure-1PSIDTS=sidts-CjEB3EgAEvCd-......"
+            },
+            "options": {
+                "logAuthUpdateChanges": true,
+                "logDiff": true
+            }
+        }
+        ```
+
+        If MS gives you authentication errors (session invalidated) at some point in the future follow the same instructions to get new cookies.
+
+    </TabItem>
+    <TabItem value="oauth" label="OAuth Client">
+        :::note
+
+        This is likely to be the most stable method and least likely to be blocked or have authentication invalidated after an extended period. It requires more setup but is worth the effort.
+        
+        :::
+
+        [Based on the instructions from here...](https://github.com/LuanRT/YouTube.js/issues/803#issuecomment-2479689924)
+
+        * Login to [Google Cloud console](https://console.cloud.google.com/) (create an account, if necessary)
+          * [Create a new project](https://console.cloud.google.com/projectcreate)
+        * Go to APIs and services.
+            * Configure the OAuth consent screen
+                * Use the old experience if possible
+                * If new is unavoidable then do not fill out any branding and under Authorized Domains you can delete the empty one (in order to save)
+                * Add yourself as an authorized user
+            * Navigate to Credentials
+                * Create Credentials -> choose "OAuth client ID"
+                    *  Application Type is **Web Application**
+                    * **Name** is whatever you want, leave Authorization Javascript origins blank
+                    * Authorized redirect URIs
+                        * This must be **exactly** the same as what is displayed in MS! For now leave it blank so we can generate it from MS first
+                * Create
+                    * In the newly created client popup save the **Client ID** and **Client Secret**, then copy them into `ytmusic.json`
+
+        ```json
+        {
+            "type": "ytmusic",
+            "enable": true,
+            "name": "MyYTM",
+            "data": {
+                "clientId": "8910....6jqupl.apps.googleusercontent.com",
+                "clientSecret": "GOCSPX-WGXL6BSuQ343..."
+            },
+            "options": {
+                "logAuthUpdateChanges": true,
+                "logDiff": true
+            }
+        }
+        ```
+
+        Now, start MS and during the YTMusic startup it will log something like this:
+
+        ```
+        Using Custom OAuth Client:
+        Client ID: ...
+        Client Secret: ...
+        Redirect URI: http://localhost:9078/api/ytmusic/callback?name=MyYTM
+        ```
+
+        If the beginning of the URL (before `api`) is EXACTLY how you would reach the MS dashboard from your browser (EX `http://localhost:9078`) then edit your google oauth client section for `Authorized redirect URIs` and add the URL MS has displayed.
+
+        If it is NOT EXACTLY the same you either need to set MS's [base url](https://foxxmd.github.io/multi-scrobbler/docs/configuration/#base-url) or you can provide your own (Custom) Redirect URI for MS to use by setting it in `ytmusic.json`.
+
+        <details>
+
+            <summary>Using a Custom Redirect URI</summary>
+
+                The three parts of the URL that must be the same:
+
+                * it must start with `api` (after domain or subdirectory IE `my.domain.tld/api...` or `whatever.tld/subDir/api...`
+                * it must end in `ytmusic/callback`
+                * It must include `name=[NameOfSource]` in the query string
+
+                Remember to add your custom URL to the `Authorized redirect URIs`  section in the google oauth client!
+
+                ```json
+                {
+                    "type": "ytmusic",
+                    "enable": true,
+                    "name": "MyYTM",
+                    "data": {
+                        "clientId": "8910....6jqupl.apps.googleusercontent.com",
+                        "clientSecret": "GOCSPX-WGXL6BSuQ343...",
+                        "redirectUri": "http://my.custom.domain/api/ytmusic/callback?name=MyYTM"
+                    },
+                    "options": {
+                        "logAuthUpdateChanges": true,
+                        "logDiff": true
+                    }
+                }
+                ```
+
+        </details>
+
+        AFTER changing the Authorized redirect URIs on Google Cloud console you may need to wait a few minutes for it to take affect. Then restart MS. From the dashboard click `(Re)authenticate` on the YTmusic source card and follow the auth flow:
+
+        * On the screen about "testing" make sure you hit **Continue** (not Back To Safety)
+        * Make sure to select ALL scopes/permissions/grants it asks you about
+          * `Select what [YourAppName] can access` -> Select all
+
+        Once the flow is finished MS will get the credentials and start polling automatically. You should not need to re-authenticate again after restarting MS as it saves the credentials to the `/config` folder.
+            
+    </TabItem>
+    <TabItem value="ytt" label="YoutubeTV">
+
+        :::warning
+
+        Using the built-in YoutubeTV authentication is unlikely to work due to [Google restricting what permissions TV clients can have](https://github.com/yt-dlp/yt-dlp/issues/11462#issuecomment-2471703090). This authentication method should not be used.
+        
+        :::   
+
+        To authenticate start multi-scrobbler with an empty YT Music configuration. An authentication URL/code will be logged in additon to being available from the dashboard.
+
+        ```
+        ERROR: Sign in with the code 'CLV-KFA-BVKY' using the authentication link on the dashboard or https://www.google.com/device
+        ```
+
+        Visit the authentication URL and enter the code that was provided (also available on the dashboard). After completing the setup flow MS will log `Auth success` and the YT Music dashboard card will display as **Idle** after refreshing. Click the **Start** link to begin monitoring.
+
+    </TabItem>
+</Tabs>
 
 #### Configuration
 

--- a/docsite/docs/configuration/configuration.mdx
+++ b/docsite/docs/configuration/configuration.mdx
@@ -886,7 +886,18 @@ Only one of these methods needs to be used. **Cookies** are easier but **OAuth C
 
 <Tabs groupId="configType" queryString>
     <TabItem value="env" label="ENV">
-        No ENV support
+
+
+
+| Environmental Variable | Required? | Default |                  Description                  |
+|------------------------|-----------|---------|-----------------------------------------------|
+| YTM_COOKIE             | No        |         | Value for Cookie Authentication               |
+| YTM_CLIENT_ID          | No        |         | Client ID for OAuth Athentication             |
+| YTM_CLIENT_SECRET      | No        |         | Client Secret for OAuth Athentication         |
+| YTM_REDIRECT_URI       | No        |         | A custom redirect URI for OAuth Athentication |
+| YTM_LOG_DIFF           | No        | false   | Log YTM history changes                       |
+
+
     </TabItem>
     <TabItem value="file" label="File">
         <details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "fixed-size-list": "^0.3.0",
         "formidable": "^3.5",
         "glob": "^11.0.0",
+        "google-auth-library": "^9.15.0",
         "gotify": "^1.1.0",
         "iso-websocket": "^0.3.0",
         "iti": "^0.6.0",
@@ -81,7 +82,7 @@
         "vite-express": "^0.16.0",
         "vlc-client": "^1.1.1",
         "xml2js": "0.6.1",
-        "youtubei.js": "^10.5.0"
+        "youtubei.js": "^11.0.1"
       },
       "devDependencies": {
         "@dbus-types/notifications": "^0.0.5",
@@ -3241,6 +3242,17 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -3587,6 +3599,14 @@
         "pnpm": ">=6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3713,6 +3733,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4599,6 +4624,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5096,6 +5129,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -5493,6 +5531,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5671,6 +5748,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.0.tgz",
+      "integrity": "sha512-7ccSEJFDFO7exFbO6NRyC+xH8/mZ1GZGG2xxx9iHxZWcjUjJpjWxIMw3cofAKcueZ6DATiukmmprD7yavQHOyQ==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5736,6 +5829,18 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -5907,6 +6012,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -6298,8 +6415,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6695,9 +6810,9 @@
       }
     },
     "node_modules/jintr": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/jintr/-/jintr-2.1.1.tgz",
-      "integrity": "sha512-89cwX4ouogeDGOBsEVsVYsnWWvWjchmwXBB4kiBhmjOKw19FiOKhNhMhpxhTlK2ctl7DS+d/ethfmuBpzoNNgA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jintr/-/jintr-3.0.2.tgz",
+      "integrity": "sha512-5g2EBudeJFOopjAX4exAv5OCCW1DgUISfoioCsm1h9Q9HJ41LmnZ6J52PCsqBlQihsmp0VDuxreAVzM7yk5nFA==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],
@@ -6748,6 +6863,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -6847,6 +6970,25 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -7512,6 +7654,25 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -10444,6 +10605,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts_lru_map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ts_lru_map/-/ts_lru_map-1.0.2.tgz",
@@ -11348,6 +11514,20 @@
         "phin": "^3.6.1"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11742,15 +11922,15 @@
       }
     },
     "node_modules/youtubei.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-10.5.0.tgz",
-      "integrity": "sha512-iyA+VF28c15tCCKH9ExM2RKC3zYiHzA/eixGlJ3vERANkuI+xYKzAZ4vtOhmyqwrAddu88R/DkzEsmpph5NWjg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-11.0.1.tgz",
+      "integrity": "sha512-ZsbOd+5XF2Ofi3FrLMfYd+f9g9H8xswlouFhjhOqbwT68dMJtX6CRGsHNj5VTFCR/+L/865x1lnUlllB2dDDTA==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "jintr": "^2.1.1",
+        "jintr": "^3.0.2",
         "tslib": "^2.5.0",
         "undici": "^5.19.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "vite-express": "^0.16.0",
         "vlc-client": "^1.1.1",
         "xml2js": "0.6.1",
-        "youtubei.js": "^11.0.1"
+        "youtubei.js": "^12.0.0"
       },
       "devDependencies": {
         "@dbus-types/notifications": "^0.0.5",
@@ -6810,9 +6810,9 @@
       }
     },
     "node_modules/jintr": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jintr/-/jintr-3.0.2.tgz",
-      "integrity": "sha512-5g2EBudeJFOopjAX4exAv5OCCW1DgUISfoioCsm1h9Q9HJ41LmnZ6J52PCsqBlQihsmp0VDuxreAVzM7yk5nFA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jintr/-/jintr-3.1.0.tgz",
+      "integrity": "sha512-azhCHApkRfBH8INpiUCwKBYaNCdB5G+x3NApsI2MxQXSlgFAx7rap3YwE3JAkN08GO8f3ilZsGB0Yvc+412ntQ==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],
@@ -11922,15 +11922,15 @@
       }
     },
     "node_modules/youtubei.js": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-11.0.1.tgz",
-      "integrity": "sha512-ZsbOd+5XF2Ofi3FrLMfYd+f9g9H8xswlouFhjhOqbwT68dMJtX6CRGsHNj5VTFCR/+L/865x1lnUlllB2dDDTA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-12.0.0.tgz",
+      "integrity": "sha512-pGmVb1I9b2gseqmuMx+BCajzVUi04+r+8zxj4Fk/iQaGQGvBCbY87Tu9mdvEgIQYTkkb4Fza7GZGrH9AjYNbrw==",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "jintr": "^3.0.2",
+        "jintr": "^3.1.0",
         "tslib": "^2.5.0",
         "undici": "^5.19.1"
       }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-express": "^0.16.0",
     "vlc-client": "^1.1.1",
     "xml2js": "0.6.1",
-    "youtubei.js": "^11.0.1"
+    "youtubei.js": "^12.0.0"
   },
   "devDependencies": {
     "@dbus-types/notifications": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "fixed-size-list": "^0.3.0",
     "formidable": "^3.5",
     "glob": "^11.0.0",
+    "google-auth-library": "^9.15.0",
     "gotify": "^1.1.0",
     "iso-websocket": "^0.3.0",
     "iti": "^0.6.0",
@@ -111,7 +112,7 @@
     "vite-express": "^0.16.0",
     "vlc-client": "^1.1.1",
     "xml2js": "0.6.1",
-    "youtubei.js": "^10.5.0"
+    "youtubei.js": "^11.0.1"
   },
   "devDependencies": {
     "@dbus-types/notifications": "^0.0.5",

--- a/src/backend/common/AbstractComponent.ts
+++ b/src/backend/common/AbstractComponent.ts
@@ -41,6 +41,7 @@ export default abstract class AbstractComponent {
     regexCache!: ReturnType<typeof cacheFunctions>;
 
     logger: Logger;
+    componentLogger?: Logger;
 
     protected constructor(config: CommonClientConfig | CommonSourceConfig) {
         this.config = config;
@@ -50,6 +51,9 @@ export default abstract class AbstractComponent {
         this.logger.debug('Attempting to initialize...');
         try {
             this.initializing = true;
+            if(this.componentLogger === undefined) {
+                await this.buildComponentLogger();
+            }
             await this.buildInitData();
             this.buildTransformRules();
             await this.checkConnection();
@@ -67,6 +71,15 @@ export default abstract class AbstractComponent {
         } finally {
             this.initializing = false;
         }
+    }
+
+    private async buildComponentLogger() {
+        await this.doBuildComponentLogger();
+        return;
+    }
+
+    protected async doBuildComponentLogger() {
+        return;
     }
 
     public async buildInitData() {

--- a/src/backend/common/infrastructure/config/source/index.ts
+++ b/src/backend/common/infrastructure/config/source/index.ts
@@ -1,3 +1,4 @@
+import { FileLogOptions, LogLevel } from "@foxxmd/logging";
 import { PlayTransformConfig, PlayTransformOptions } from "../../Atomic.js";
 import { CommonConfig, CommonData, RequestRetryOptions } from "../common.js";
 
@@ -71,6 +72,13 @@ export interface CommonSourceOptions extends SourceRetryOptions {
      * @examples [false]
      * */
     logPlayerState?: boolean
+
+    /**
+     * **Exprimental:** Log to a separate file for this Source.
+     * 
+     * Useful for debugging long-running Sources
+     */
+    logToFile?: true | LogLevel | FileLogOptions
 
     /**
      * If this source

--- a/src/backend/common/infrastructure/config/source/ytmusic.ts
+++ b/src/backend/common/infrastructure/config/source/ytmusic.ts
@@ -1,11 +1,42 @@
 import { PollingOptions } from "../common.js";
 import { CommonSourceConfig, CommonSourceData, CommonSourceOptions } from "./index.js";
-import { Innertube } from 'youtubei.js';
 
-//type InnertubeOptions = Omit<Parameters<typeof Innertube.create>[0], 'cookie' | 'cache' | 'fetch'>;
+export interface InnertubeOptions {
+    /**
+     * Proof of Origin token
+     * 
+     * May be required if YTM starts returning 403
+     * 
+     * @see https://github.com/yt-dlp/yt-dlp/wiki/Extractors#po-token-guide
+     */
+    po_token?: string
+
+    /**
+     * Visitor ID value found in VISITOR_INFO1_LIVE or visitorData cookie
+     * 
+     * May be required if YTM starts returning 403
+     * 
+     * @see https://github.com/yt-dlp/yt-dlp/wiki/Extractors#po-token-guide
+     */
+    visitor_data?: string
+
+    /**
+     * If account login results in being able to choose multiple account, use a zero-based index to choose which one to monitor
+     * 
+     * @examples [0,1]
+     */
+    account_index?: number
+
+    location?: string
+    lang?: string
+    generate_session_locally?: boolean
+    device_category?: string
+    client_type?: string
+    timezone?: string
+}
 
 export interface YTMusicData extends CommonSourceData, PollingOptions {
-        /**
+    /**
      * The cookie retrieved from the Request Headers of music.youtube.com after logging in.
      *
      * See https://ytmusicapi.readthedocs.io/en/stable/setup/browser.html#copy-authentication-headers for how to retrieve this value.
@@ -14,13 +45,33 @@ export interface YTMusicData extends CommonSourceData, PollingOptions {
      * */
     cookie?: string
 
+    /**
+     * Google Cloud Console project OAuth Client ID
+     * 
+     * Generated from a custom OAuth Client, see docs
+     */
     clientId?: string
     
+    /**
+     * Google Cloud Console project OAuth Client Secret
+     * 
+     * Generated from a custom OAuth Client, see docs
+     */
     clientSecret?: string
 
+    /**
+     * Google Cloud Console project OAuth Client Authorized redirect URI
+     * 
+     * Generated from a custom OAuth Client, see docs. multi-scrobbler will generate a default based on BASE_URL.
+     * Only specify this if the default does not work for you.
+     */
     redirectUri?: string
+
+    /**
+     * Additional options for authorization and tailoring YTM client
+     */
+    innertubeOptions?: InnertubeOptions
 }
-//export type YTMusicData = YTMusicDataCommon & InnertubeOptions;
 
 export interface YTMusicSourceConfig extends CommonSourceConfig {
     data?: YTMusicData

--- a/src/backend/common/infrastructure/config/source/ytmusic.ts
+++ b/src/backend/common/infrastructure/config/source/ytmusic.ts
@@ -1,8 +1,27 @@
 import { PollingOptions } from "../common.js";
 import { CommonSourceConfig, CommonSourceData, CommonSourceOptions } from "./index.js";
+import { Innertube } from 'youtubei.js';
+
+//type InnertubeOptions = Omit<Parameters<typeof Innertube.create>[0], 'cookie' | 'cache' | 'fetch'>;
 
 export interface YTMusicData extends CommonSourceData, PollingOptions {
+        /**
+     * The cookie retrieved from the Request Headers of music.youtube.com after logging in.
+     *
+     * See https://ytmusicapi.readthedocs.io/en/stable/setup/browser.html#copy-authentication-headers for how to retrieve this value.
+     *
+     * @examples ["VISITOR_INFO1_LIVE=jMp2xA1Xz2_PbVc; __Secure-3PAPISID=3AxsXpy0M/AkISpjek; ..."]
+     * */
+    cookie?: string
+
+    clientId?: string
+    
+    clientSecret?: string
+
+    redirectUri?: string
 }
+//export type YTMusicData = YTMusicDataCommon & InnertubeOptions;
+
 export interface YTMusicSourceConfig extends CommonSourceConfig {
     data?: YTMusicData
     options?: CommonSourceOptions & {

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -82,7 +82,7 @@ const configDir = process.env.CONFIG_DIR || path.resolve(projectDir, `./config`)
         const [aLogger, appLoggerStream] = await appLogger(logging)
         logger = childLogger(aLogger, 'App');
 
-        const root = getRoot({...config, logger});
+        const root = getRoot({...config, logger, loggingConfig: logging, loggerStream: appLoggerStream});
         initLogger.info(`Version: ${root.get('version')}`);
 
         initLogger.info('Generating schema definitions...');

--- a/src/backend/ioc.ts
+++ b/src/backend/ioc.ts
@@ -1,5 +1,5 @@
 import { getVersion } from "@foxxmd/get-version";
-import { Logger } from "@foxxmd/logging";
+import { Logger, LogOptions } from "@foxxmd/logging";
 import { EventEmitter } from "events";
 import { createContainer } from "iti";
 import path from "path";
@@ -9,6 +9,7 @@ import { Notifiers } from "./notifier/Notifiers.js";
 import ScrobbleClients from "./scrobblers/ScrobbleClients.js";
 import ScrobbleSources from "./sources/ScrobbleSources.js";
 import { generateBaseURL } from "./utils.js";
+import { PassThrough } from "stream";
 
 let version: string = 'unknown';
 
@@ -23,13 +24,17 @@ export interface RootOptions {
     port?: string | number
     logger: Logger
     disableWeb?: boolean
+    loggerStream?: PassThrough
+    loggingConfig?: LogOptions
 }
 
 const createRoot = (options?: RootOptions) => {
     const {
         port = 9078,
         baseUrl = process.env.BASE_URL,
-        disableWeb: dw
+        disableWeb: dw,
+        loggerStream,
+        loggingConfig
     } = options || {};
     const configDir = process.env.CONFIG_DIR || path.resolve(projectDir, `./config`);
     let disableWeb = dw;
@@ -54,6 +59,8 @@ const createRoot = (options?: RootOptions) => {
         clientEmitter: () => cEmitter,
         sourceEmitter: () => sEmitter,
         notifierEmitter: () => new EventEmitter(),
+        loggerStream,
+        loggingConfig,
     }).add((items) => {
         const localUrl = generateBaseURL(baseUrl, items.port)
         return {

--- a/src/backend/sources/ScrobbleSources.ts
+++ b/src/backend/sources/ScrobbleSources.ts
@@ -26,7 +26,7 @@ import { SubsonicData, SubSonicSourceConfig } from "../common/infrastructure/con
 import { TautulliSourceConfig } from "../common/infrastructure/config/source/tautulli.js";
 import { VLCData, VLCSourceConfig } from "../common/infrastructure/config/source/vlc.js";
 import { WebScrobblerSourceConfig } from "../common/infrastructure/config/source/webscrobbler.js";
-import { YTMusicSourceConfig } from "../common/infrastructure/config/source/ytmusic.js";
+import { YTMusicData, YTMusicSourceConfig } from "../common/infrastructure/config/source/ytmusic.js";
 import { WildcardEmitter } from "../common/WildcardEmitter.js";
 import { parseBool, readJson } from "../utils.js";
 import { validateJson } from "../utils/ValidationUtils.js";
@@ -484,6 +484,24 @@ export default class ScrobbleSources {
                         });
                     }
                     break;
+                case 'ytmusic':
+                    const ytm = {
+                        redirectUri: process.env.YTM_REDIRECT_URI,
+                        clientId: process.env.YTM_CLIENT_ID,
+                        clientSecret: process.env.YTM_CLIENT_SECRET,
+                        cookie: process.env.YTM_COOKIE
+                    }
+                    if (!Object.values(ytm).every(x => x === undefined)) {
+                        configs.push({
+                            type: 'ytmusic',
+                            name: 'unnamed',
+                            source: 'ENV',
+                            mode: 'single',
+                            configureAs: defaultConfigureAs,
+                            data: ytm as YTMusicData
+                        });
+                    }
+                    break;                    
                 default:
                     break;
             }

--- a/src/backend/sources/YTMusicSource.ts
+++ b/src/backend/sources/YTMusicSource.ts
@@ -3,7 +3,7 @@ import EventEmitter from "events";
 import { PlayObject } from "../../core/Atomic.js";
 import { FormatPlayObjectOptions, InternalConfig } from "../common/infrastructure/Atomic.js";
 import { YTMusicSourceConfig } from "../common/infrastructure/config/source/ytmusic.js";
-import { Innertube, UniversalCache, Parser, YTNodes, ApiResponse, IBrowseResponse, Log } from 'youtubei.js';
+import { Innertube, UniversalCache, Parser, YTNodes, ApiResponse, IBrowseResponse, Log, SessionOptions } from 'youtubei.js';
 import { OAuth2Client } from 'google-auth-library';
 import {resolve} from 'path';
 import { joinedUrl, sleep } from "../utils.js";
@@ -92,8 +92,13 @@ export default class YTMusicSource extends AbstractSource {
     }
 
     protected async doBuildInitData(): Promise<true | string | undefined> {
+        const {
+            cookie,
+            innertubeOptions = {},
+        } = this.config.data || {};
         this.yti = await Innertube.create({
-            ...this.config.data,
+            ...(innertubeOptions as SessionOptions),
+            cookie,
             cache: new UniversalCache(true, this.workingCredsPath)
         });
         this.yti.session.on('update-credentials', async ({ credentials }) => {

--- a/src/backend/sources/YTMusicSource.ts
+++ b/src/backend/sources/YTMusicSource.ts
@@ -191,7 +191,7 @@ export default class YTMusicSource extends AbstractSource {
             if (this.authed === false) {
 
                 if (this.config.data.clientId !== undefined) {
-                    const redirectUri = this.config.data?.redirectUri ?? joinedUrl(this.localUrl, `ytmusic/callback?name=${this.name}`).toString();
+                    const redirectUri = this.config.data?.redirectUri ?? joinedUrl(this.localUrl, `api/ytmusic/callback?name=${this.name}`).toString();
 
                     this.logger.info(`Using Custom OAuth Client with Redirect URI: ${redirectUri}`);
                     this.oauthClient = new OAuth2Client({

--- a/src/backend/sources/YTMusicSource.ts
+++ b/src/backend/sources/YTMusicSource.ts
@@ -6,7 +6,7 @@ import { YTMusicSourceConfig } from "../common/infrastructure/config/source/ytmu
 import { Innertube, UniversalCache, Parser, YTNodes, ApiResponse, IBrowseResponse, Log, SessionOptions } from 'youtubei.js';
 import { GenerateAuthUrlOpts, OAuth2Client } from 'google-auth-library';
 import {resolve} from 'path';
-import { joinedUrl, sleep } from "../utils.js";
+import { joinedUrl, parseBool, sleep } from "../utils.js";
 import {
     getPlaysDiff,
     humanReadableDiff,
@@ -92,6 +92,16 @@ export default class YTMusicSource extends AbstractSource {
         this.canPoll = true;
         this.supportsUpstreamRecentlyPlayed = true;
         this.workingCredsPath = resolve(this.configDir, `yti-${this.name}`);
+
+        const diffEnv = process.env.YTM_LOG_DIFF;
+        if(diffEnv !== undefined && this.config.options?.logDiff === undefined) {
+            const logDiff = parseBool(diffEnv);
+            const opts = this.config.options ?? {};
+            this.config.options = {
+                ...opts,
+                logDiff
+            }
+        }
     }
 
     public additionalApiData(): Record<string, any> {

--- a/src/backend/sources/YTMusicSource.ts
+++ b/src/backend/sources/YTMusicSource.ts
@@ -196,7 +196,12 @@ export default class YTMusicSource extends AbstractSource {
             if (this.authed === false) {
 
                 if (this.config.data.clientId !== undefined) {
-                    const redirectUri = this.config.data?.redirectUri ?? joinedUrl(this.localUrl, `api/ytmusic/callback?name=${this.name}`).toString();
+                    let redirectUri = this.config.data?.redirectUri;
+                    if(redirectUri === undefined) {
+                        const u = joinedUrl(this.localUrl, 'api/ytmusic/callback');
+                        u.searchParams.append('name', this.name);
+                        redirectUri = u.toString();
+                    } 
 
                     this.logger.info(`Using Custom OAuth Client with Redirect URI: ${redirectUri}`);
                     this.oauthClient = new OAuth2Client({


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Describe your changes

Youtube TV seems no longer have scope for reading history or account details. Cookies may work and custom oauth seems most stable based on reporting from LuanRT/YouTube.js#803

* Re-implement cookie auth
* Implement custom OAuth Client auth based on [example](https://github.com/LuanRT/YouTube.js/blob/main/examples/auth/custom-oauth2-creds/index.ts)

## TODO

- [x] Add FAQ entry for common YTM auth issues, refer to [yt-dlp known issues](https://github.com/yt-dlp/yt-dlp/issues/3766) for some general guidance
  - [x] Add [guidance from yt-dlp about exporting cookies](https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies)
- [x] Update YTM config with cookie and oauth setup

## Issue number and link, if applicable

#195 
#229
#203