### PR TITLE
Implement multi-runner image build for multi-arch improvements

### DIFF
--- a/.github/act/multiRunnerTest.yml
+++ b/.github/act/multiRunnerTest.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set short git commit SHA
         id: appvars
@@ -64,17 +64,17 @@ jobs:
         run: |
           echo appversion=$APP_VERSION >>${GITHUB_OUTPUT}
       
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.DOCKERHUB_SLUG }}
-            ${{ env.GHCR_SLUG }}
-          labels: |
-            org.opencontainers.image.title=Multi-Scrobbler
-            org.opencontainers.image.description=Scrobble from many sources to many clients
-            org.opencontainers.image.vendor=FoxxMD
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@v5
+      #   with:
+      #     images: |
+      #       ${{ env.DOCKERHUB_SLUG }}
+      #       ${{ env.GHCR_SLUG }}
+      #     labels: |
+      #       org.opencontainers.image.title=Multi-Scrobbler
+      #       org.opencontainers.image.description=Scrobble from many sources to many clients
+      #       org.opencontainers.image.vendor=FoxxMD
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -138,6 +138,19 @@ jobs:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -155,7 +168,7 @@ jobs:
             type=edge
 
             # maybe re-enable branch-named tags in the futures
-            #type=ref,event=branch,enable=${{ !endsWith(github.ref, 'master') }}
+            type=ref,event=branch,enable=${{ !endsWith(github.ref, 'master') }}
             
             # tag non-prelease as latest -- has a higher priority than regular tag so it shows first in registries
             type=match,pattern=\d.\d.\d$,priority=901
@@ -169,27 +182,17 @@ jobs:
             org.opencontainers.image.description=Scrobble from many sources to many clients
             org.opencontainers.image.vendor=FoxxMD
       
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map(select(startswith("${{ env.DOCKERHUB_SLUG }}")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKERHUB_SLUG }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.tags | map(select(startswith("${{ env.GHCR_SLUG }}")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_SLUG }}@sha256:%s ' *)          
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_SLUG }}@sha256:%s ' *)        
       
-      # - name: Inspect image
-      #   run: |
-      #     docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:${{ steps.meta.outputs.version }}      

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,9 @@
 name: PR Workflow
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
 on:
   pull_request_target:
     types:
@@ -17,11 +21,11 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha }}
 
-  release-snapshot:
-    name: Release snapshot
-    runs-on: ubuntu-latest
+  build-snapshot:
+    name: Build OCI snapshot
     needs: test
     if: contains(github.event.pull_request.labels.*.name, 'safe to test')
+    runs-on: ${{ matrix.os }}
     permissions:
       packages: write
       contents: read
@@ -29,40 +33,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dockerfile: ./Dockerfile
-            suffix: ''
-            platforms: 'linux/amd64,linux/arm64'
+          - os: ubuntu-latest
+            arch: amd64
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            platform: linux/arm64
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV     
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            foxxmd/multi-scrobbler
-            ghcr.io/foxxmd/multi-scrobbler
-          tags: |
-            type=ref,event=pr,suffix=${{ matrix.suffix }}
-          flavor: |
-            latest=false
+          # list all registries to push to and join all non-empty with comma
+          # https://unix.stackexchange.com/a/693165/116849
+          # https://stackoverflow.com/a/9429887/1469797
+          strings=("${{vars.DOCKERHUB_SLUG}}" "${{vars.GHCR_SLUG}}")
+          for i in ${!strings[@]}; do [[ -z ${strings[i]} ]] && unset strings[i]; done
+          joined_string=$(IFS=, ; echo "${strings[*]}")
+          echo "REGISTRIES_JOINED=$joined_string" >> $GITHUB_ENV 
 
       - uses: actions/checkout@v4
         with:
@@ -73,20 +62,139 @@ jobs:
           short=$(echo "${{ github.event.pull_request.head.sha }}" | head -c7)
           echo "COMMIT_SHORT_SHA=$short" >> $GITHUB_ENV
 
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v5
+      - name: Get App Version
+        id: appversion
         env:
           APP_VERSION: ${{ format('pr{0}-{1}', github.event.number, env.COMMIT_SHORT_SHA ) }}
+        run: |
+          echo appversion=$APP_VERSION >>${GITHUB_OUTPUT}
+
+      - name: Login to Docker Hub
+        if: ${{ vars.DOCKERHUB_SLUG != '' }}
+        uses: docker/login-action@v3
         with:
-          context: .
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+  
+      - name: Login to GitHub Container Registry
+        if: ${{ vars.GHCR_SLUG != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # metadata extract for docker labels/image names is done in merge job
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # https://github.com/docker/build-push-action/issues/671#issuecomment-1619353328
+      # for caching
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
           build-args: |
-            APP_BUILD_VERSION=${{env.APP_VERSION}}
-          file: ${{ matrix.dockerfile }}
-          push: ${{ !env.ACT}}
-          tags: ${{ steps.meta.outputs.tags }}
+            APP_BUILD_VERSION=${{steps.appversion.outputs.appversion}}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platforms }}
+          outputs: type=image,"name=${{ env.REGISTRIES_JOINED }}",push-by-digest=true,name-canonical=true,push=true
+          #cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
+          #cache-to: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release-snapshot:
+    name: Merge OCI Images and Push
+    if: ${{ vars.DOCKERHUB_SLUG != '' ||  vars.GHCR_SLUG != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    needs:
+      - build-snapshot
+      - test
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        if: ${{ vars.DOCKERHUB_SLUG != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        if: ${{ vars.GHCR_SLUG != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ vars.DOCKERHUB_SLUG }}
+            ${{ vars.GHCR_SLUG }}
+          # generate Docker tags based on the following events/attributes
+          # https://github.com/docker/metadata-action/issues/247#issuecomment-1511259674 for NOT is default branch, eventually
+          tags: |
+            type=ref,event=pr
+          flavor: |
+            latest=false
+          labels: |
+            org.opencontainers.image.title=Multi-Scrobbler
+            org.opencontainers.image.description=Scrobble from many sources to many clients
+            org.opencontainers.image.vendor=FoxxMD
+      
+      - name: Create manifest list and push dockerhub
+        if: ${{ vars.DOCKERHUB_SLUG != '' }}
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ vars.DOCKERHUB_SLUG }}@sha256:%s ' *)
+      
+      - name: Create manifest list and push gchr
+        if: ${{ vars.GHCR_SLUG != '' }}
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ vars.GHCR_SLUG }}@sha256:%s ' *)    
+      
+      - name: Inspect image dockerhub
+        if: ${{ vars.DOCKERHUB_SLUG != '' }}
+        run: |
+          docker buildx imagetools inspect ${{ vars.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
+
+      - name: Inspect image ghcr
+        if: ${{ vars.GHCR_SLUG != '' }}
+        run: |
+            docker buildx imagetools inspect ${{ vars.GHCR_SLUG }}:${{ steps.meta.outputs.version }}   
+
 
   combine-and-comment:
     name: Leave comment

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -24,9 +24,11 @@ on:
 #  release:
 #    types: [ published ]
 
-# define repository actions vars to enable pushing to registries IE
-# DOCKERHUB_SLUG: foxxmd/multi-scrobbler
-# GHCR_SLUG: ghcr.io/foxxmd/multi-scrobbler
+# define in GH Repository -> Actions -> Variables (or act .variables) to enable pushing to registries
+# -- will only push to registries that are defined
+# EX
+# DOCKERHUB_SLUG=foxxmd/multi-scrobbler
+# GHCR_SLUG=ghcr.io/foxxmd/multi-scrobbler
   
 jobs:
   test:
@@ -56,6 +58,7 @@ jobs:
 
           # list all registries to push to and join all non-empty with comma
           # https://unix.stackexchange.com/a/693165/116849
+          # https://stackoverflow.com/a/9429887/1469797
           strings=("${{vars.DOCKERHUB_SLUG}}" "${{vars.GHCR_SLUG}}")
           for i in ${!strings[@]}; do [[ -z ${strings[i]} ]] && unset strings[i]; done
           joined_string=$(IFS=, ; echo "${strings[*]}")

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -1,43 +1,49 @@
-name: Publish Docker image to Dockerhub
+# Based on https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+
+name: build
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - 'master'
     tags:
       - '*.*.*'
-    # don't trigger if just updating docs
     paths-ignore:
       - 'README.md'
       - '.github/**'
       - 'flatpak/**'
-  # use release instead of tags once version is correctly parsed
-  # https://github.com/docker/metadata-action/issues/422
-  # https://github.com/docker/metadata-action/issues/240
-#  release:
-#    types: [ published ]
+
+env:
+  DOCKERHUB_SLUG: foxxmd/multi-scrobbler
+  GHCR_SLUG: ghcr.io/foxxmd/multi-scrobbler
 
 jobs:
-  test:
-    if: github.event_name != 'pull_request'
-    uses: ./.github/workflows/testAndSanity.yml
-
-  push_to_registry:
-    name: Build and push container images
-    if: github.event_name != 'pull_request'
+  build:
     runs-on: ubuntu-latest
-    needs: test
-    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
       packages: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
+
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set short git commit SHA
-        id: vars
+        id: appvars
         # https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
         # short sha available under env.COMMIT_SHORT_SHA
         run: |
@@ -46,7 +52,37 @@ jobs:
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
           echo "COMMIT_BRANCH=$branchName" >> $GITHUB_ENV
 
-      - name: Log in to Docker Hub
+      - name: Get App Version
+        id: appversion
+        env:
+          # use release instead of tags once version is correctly parsed
+          #APP_VERSION: ${{ github.event.release.tag_name }}
+
+          # https://github.com/actions/runner/issues/409#issuecomment-752775072
+          # https://stackoverflow.com/a/69919067/1469797
+          APP_VERSION: ${{ contains(github.ref, 'refs/tags/') && github.ref_name || format('{0}-{1}', env.COMMIT_BRANCH, env.COMMIT_SHORT_SHA ) }}
+        run: |
+          echo appversion=$APP_VERSION >>${GITHUB_OUTPUT}
+      
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@v5
+      #   with:
+      #     images: |
+      #       ${{ env.DOCKERHUB_SLUG }}
+      #       ${{ env.GHCR_SLUG }}
+      #     labels: |
+      #       org.opencontainers.image.title=Multi-Scrobbler
+      #       org.opencontainers.image.description=Scrobble from many sources to many clients
+      #       org.opencontainers.image.vendor=FoxxMD
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -59,20 +95,80 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
+      # https://github.com/docker/build-push-action/issues/671#issuecomment-1619353328
+      # for caching
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            APP_BUILD_VERSION=${{steps.appversion.outputs.appversion}}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          #tags: ${{ steps.meta.outputs.tags }}
+          outputs: type=image,"name=${{ env.DOCKERHUB_SLUG }},${{ env.GHCR_SLUG }}",push-by-digest=true,name-canonical=true,push=true
+          #cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
+          #cache-to: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
+      
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            foxxmd/multi-scrobbler
-            ghcr.io/foxxmd/multi-scrobbler
+            ${{ env.DOCKERHUB_SLUG }}
+            ${{ env.GHCR_SLUG }}
           # generate Docker tags based on the following events/attributes
           # https://github.com/docker/metadata-action/issues/247#issuecomment-1511259674 for NOT is default branch, eventually
           tags: |
             type=edge
 
             # maybe re-enable branch-named tags in the futures
-            #type=ref,event=branch,enable=${{ !endsWith(github.ref, 'master') }}
+            type=ref,event=branch,enable=${{ !endsWith(github.ref, 'master') }}
             
             # tag non-prelease as latest -- has a higher priority than regular tag so it shows first in registries
             type=match,pattern=\d.\d.\d$,priority=901
@@ -81,28 +177,22 @@ jobs:
             type=semver,pattern={{version}}
         #  flavor: |
         #    latest=false
+          labels: |
+            org.opencontainers.image.title=Multi-Scrobbler
+            org.opencontainers.image.description=Scrobble from many sources to many clients
+            org.opencontainers.image.vendor=FoxxMD
+      
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push Docker image
-        env:
-          # use release instead of tags once version is correctly parsed
-          #APP_VERSION: ${{ github.event.release.tag_name }}
-
-        # https://github.com/actions/runner/issues/409#issuecomment-752775072
-        # https://stackoverflow.com/a/69919067/1469797
-          APP_VERSION: ${{ contains(github.ref, 'refs/tags/') && github.ref_name || format('{0}-{1}', env.COMMIT_BRANCH, env.COMMIT_SHORT_SHA ) }}
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          # https://github.com/docker/build-push-action/issues/1026#issue-2041857786
-          build-args: |
-            APP_BUILD_VERSION=${{env.APP_VERSION}}
-          push: ${{ !env.ACT }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKERHUB_SLUG }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_SLUG }}@sha256:%s ' *)        
+      
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:${{ steps.meta.outputs.version }}      

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -1,6 +1,6 @@
 # Based on https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
 
-name: build
+name: Publish Docker image to Dockerhub
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -46,10 +46,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # does this need os/arch instead of platform? https://learn.arm.com/learning-paths/cross-platform/github-arm-runners/actions/
-        # platform:
-        #   - linux/amd64
-        #   - linux/arm64
         include:
           - os: ubuntu-latest
             arch: amd64
@@ -112,12 +108,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       
       # metadata extract for docker labels/image names is done in merge job
-      
-      # REMOVE(??) once arm runners are publicly available
-      # https://github.com/orgs/community/discussions/142209#discussioncomment-11107737
-      # https://github.com/github/roadmap/issues/970
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -54,6 +54,8 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV     
 
+          # list all registries to push to and join all non-empty with comma
+          # https://unix.stackexchange.com/a/693165/116849
           strings=("${{vars.DOCKERHUB_SLUG}}" "${{vars.GHCR_SLUG}}")
           for i in ${!strings[@]}; do [[ -z ${strings[i]} ]] && unset strings[i]; done
           joined_string=$(IFS=, ; echo "${strings[*]}")
@@ -120,8 +122,6 @@ jobs:
             APP_BUILD_VERSION=${{steps.appversion.outputs.appversion}}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          #tags: ${{ steps.meta.outputs.tags }}
-          #outputs: type=image,"name=${{ env.DOCKERHUB_SLUG }},${{ env.GHCR_SLUG }}",push-by-digest=true,name-canonical=true,push=true
           outputs: type=image,"name=${{ env.REGISTRIES_JOINED }}",push-by-digest=true,name-canonical=true,push=true
           #cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
           #cache-to: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
@@ -176,7 +176,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -203,38 +203,26 @@ jobs:
             org.opencontainers.image.description=Scrobble from many sources to many clients
             org.opencontainers.image.vendor=FoxxMD
       
-      - name: Create manifest list and push
+      - name: Create manifest list and push dockerhub
         if: ${{ vars.DOCKERHUB_SLUG != '' }}
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ vars.DOCKERHUB_SLUG }}@sha256:%s ' *)
       
-      - name: Create manifest list and push
+      - name: Create manifest list and push gchr
         if: ${{ vars.GHCR_SLUG != '' }}
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ vars.GHCR_SLUG }}@sha256:%s ' *)
-      # - name: Create manifest list and push
-      #   working-directory: /tmp/digests
-      #   run: |
-      #     docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-      #       $(printf '${{ env.DOCKERHUB_SLUG }}@sha256:%s ' *)
-      #     docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-      #       $(printf '${{ env.GHCR_SLUG }}@sha256:%s ' *)        
+            $(printf '${{ vars.GHCR_SLUG }}@sha256:%s ' *)    
       
-      - name: Inspect image
+      - name: Inspect image dockerhub
         if: ${{ vars.DOCKERHUB_SLUG != '' }}
         run: |
           docker buildx imagetools inspect ${{ vars.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
 
-      - name: Inspect image
+      - name: Inspect image ghcr
         if: ${{ vars.GHCR_SLUG != '' }}
         run: |
-            docker buildx imagetools inspect ${{ vars.GHCR_SLUG }}:${{ steps.meta.outputs.version }}
-            
-      # - name: Inspect image
-      #   run: |
-      #     docker buildx imagetools inspect ${{ env.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
-      #     docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:${{ steps.meta.outputs.version }}      
+            docker buildx imagetools inspect ${{ vars.GHCR_SLUG }}:${{ steps.meta.outputs.version }}   

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -13,17 +13,30 @@ on:
       - 'master'
     tags:
       - '*.*.*'
+    # don't trigger if just updating docs
     paths-ignore:
       - 'README.md'
       - '.github/**'
       - 'flatpak/**'
+  # use release instead of tags once version is correctly parsed
+  # https://github.com/docker/metadata-action/issues/422
+  # https://github.com/docker/metadata-action/issues/240
+#  release:
+#    types: [ published ]
 
-env:
-  DOCKERHUB_SLUG: foxxmd/multi-scrobbler
-  GHCR_SLUG: ghcr.io/foxxmd/multi-scrobbler
-
+# define repository actions vars to enable pushing to registries IE
+# DOCKERHUB_SLUG: foxxmd/multi-scrobbler
+# GHCR_SLUG: ghcr.io/foxxmd/multi-scrobbler
+  
 jobs:
+  test:
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/testAndSanity.yml
+
   build:
+    name: Build OCI Images
+    if: ${{ github.event_name != 'pull_request' && (vars.DOCKERHUB_SLUG != '' ||  vars.GHCR_SLUG != '') }}
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -31,6 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # does this need os/arch instead of platform? https://learn.arm.com/learning-paths/cross-platform/github-arm-runners/actions/
         platform:
           - linux/amd64
           - linux/arm64
@@ -38,7 +52,12 @@ jobs:
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV     
+
+          strings=("${{vars.DOCKERHUB_SLUG}}" "${{vars.GHCR_SLUG}}")
+          for i in ${!strings[@]}; do [[ -z ${strings[i]} ]] && unset strings[i]; done
+          joined_string=$(IFS=, ; echo "${strings[*]}")
+          echo "REGISTRIES_JOINED=$joined_string" >> $GITHUB_ENV 
 
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -64,37 +83,32 @@ jobs:
           APP_VERSION: ${{ contains(github.ref, 'refs/tags/') && github.ref_name || format('{0}-{1}', env.COMMIT_BRANCH, env.COMMIT_SHORT_SHA ) }}
         run: |
           echo appversion=$APP_VERSION >>${GITHUB_OUTPUT}
-      
-      # - name: Extract metadata (tags, labels) for Docker
-      #   id: meta
-      #   uses: docker/metadata-action@v5
-      #   with:
-      #     images: |
-      #       ${{ env.DOCKERHUB_SLUG }}
-      #       ${{ env.GHCR_SLUG }}
-      #     labels: |
-      #       org.opencontainers.image.title=Multi-Scrobbler
-      #       org.opencontainers.image.description=Scrobble from many sources to many clients
-      #       org.opencontainers.image.vendor=FoxxMD
-      
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' && vars.DOCKERHUB_SLUG != '' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
+  
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' && vars.GHCR_SLUG != '' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      # metadata extract for docker labels/image names is done in merge job
+      
+      # REMOVE(??) once arm runners are publicly available
+      # https://github.com/orgs/community/discussions/142209#discussioncomment-11107737
+      # https://github.com/github/roadmap/issues/970
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       
       # https://github.com/docker/build-push-action/issues/671#issuecomment-1619353328
       # for caching
@@ -107,7 +121,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           #tags: ${{ steps.meta.outputs.tags }}
-          outputs: type=image,"name=${{ env.DOCKERHUB_SLUG }},${{ env.GHCR_SLUG }}",push-by-digest=true,name-canonical=true,push=true
+          #outputs: type=image,"name=${{ env.DOCKERHUB_SLUG }},${{ env.GHCR_SLUG }}",push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,"name=${{ env.REGISTRIES_JOINED }}",push-by-digest=true,name-canonical=true,push=true
           #cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
           #cache-to: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
       
@@ -126,12 +141,15 @@ jobs:
           retention-days: 1
 
   merge:
+    name: Merge OCI Images and Push
+    if: ${{ github.event_name != 'pull_request' && (vars.DOCKERHUB_SLUG != '' ||  vars.GHCR_SLUG != '') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
     needs:
       - build
+      - test
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -141,12 +159,14 @@ jobs:
           merge-multiple: true
 
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' && vars.DOCKERHUB_SLUG != '' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' && vars.GHCR_SLUG != '' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -161,14 +181,14 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.DOCKERHUB_SLUG }}
-            ${{ env.GHCR_SLUG }}
+            ${{ vars.DOCKERHUB_SLUG }}
+            ${{ vars.GHCR_SLUG }}
           # generate Docker tags based on the following events/attributes
           # https://github.com/docker/metadata-action/issues/247#issuecomment-1511259674 for NOT is default branch, eventually
           tags: |
             type=edge
 
-            # maybe re-enable branch-named tags in the futures
+            # push with branch name as tag if not master/main
             type=ref,event=branch,enable=${{ !endsWith(github.ref, 'master') }}
             
             # tag non-prelease as latest -- has a higher priority than regular tag so it shows first in registries
@@ -183,17 +203,38 @@ jobs:
             org.opencontainers.image.description=Scrobble from many sources to many clients
             org.opencontainers.image.vendor=FoxxMD
       
-
-      
       - name: Create manifest list and push
+        if: ${{ vars.DOCKERHUB_SLUG != '' }}
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.DOCKERHUB_SLUG }}@sha256:%s ' *)
+            $(printf '${{ vars.DOCKERHUB_SLUG }}@sha256:%s ' *)
+      
+      - name: Create manifest list and push
+        if: ${{ vars.GHCR_SLUG != '' }}
+        working-directory: /tmp/digests
+        run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_SLUG }}@sha256:%s ' *)        
+            $(printf '${{ vars.GHCR_SLUG }}@sha256:%s ' *)
+      # - name: Create manifest list and push
+      #   working-directory: /tmp/digests
+      #   run: |
+      #     docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+      #       $(printf '${{ env.DOCKERHUB_SLUG }}@sha256:%s ' *)
+      #     docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+      #       $(printf '${{ env.GHCR_SLUG }}@sha256:%s ' *)        
       
       - name: Inspect image
+        if: ${{ vars.DOCKERHUB_SLUG != '' }}
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
-          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:${{ steps.meta.outputs.version }}      
+          docker buildx imagetools inspect ${{ vars.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
+
+      - name: Inspect image
+        if: ${{ vars.GHCR_SLUG != '' }}
+        run: |
+            docker buildx imagetools inspect ${{ vars.GHCR_SLUG }}:${{ steps.meta.outputs.version }}
+            
+      # - name: Inspect image
+      #   run: |
+      #     docker buildx imagetools inspect ${{ env.DOCKERHUB_SLUG }}:${{ steps.meta.outputs.version }}
+      #     docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:${{ steps.meta.outputs.version }}      

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -41,7 +41,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
 
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Set short git commit SHA
         id: appvars

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build OCI Images
     if: ${{ github.event_name != 'pull_request' && (vars.DOCKERHUB_SLUG != '' ||  vars.GHCR_SLUG != '') }}
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -7,6 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -47,9 +47,16 @@ jobs:
       fail-fast: false
       matrix:
         # does this need os/arch instead of platform? https://learn.arm.com/learning-paths/cross-platform/github-arm-runners/actions/
-        platform:
-          - linux/amd64
-          - linux/arm64
+        # platform:
+        #   - linux/amd64
+        #   - linux/arm64
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            platform: linux/arm64
     steps:
       - name: Prepare
         run: |
@@ -109,8 +116,8 @@ jobs:
       # REMOVE(??) once arm runners are publicly available
       # https://github.com/orgs/community/discussions/142209#discussioncomment-11107737
       # https://github.com/github/roadmap/issues/970
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

* [x] Refactor publish workflow to use multiple runners for bare-metal cross-arch image builds instead of  using QEMU emulation
* [ ] Remove QEMU steps to use bare-metal
  * Somewhat blocked by required release of ARM runners for public use
    * https://github.com/github/roadmap/issues/970
    * https://github.com/actions/runner-images/issues/10820
    * https://github.com/orgs/community/discussions/142209#discussioncomment-11107737
  * Until this is unblocked we need to keep QEMU step so performance is same as current build workflows
* [x] Refactor publish workflow to use repository vars for registries to push to instead of hardcoding
  * Makes it easier for other users to fork and publish easily by only adding repo vars/secrets 
* [ ] Refactor PR workflow with all of the above changes as well
