### PR TITLE
fix(ytm): Improve history handling

### DIFF
--- a/src/backend/sources/AbstractSource.ts
+++ b/src/backend/sources/AbstractSource.ts
@@ -416,8 +416,11 @@ export default abstract class AbstractSource extends AbstractComponent implement
                         // because the interval check was so close to the play date we are going to delay client calls for a few secs
                         // this way we don't accidentally scrobble ahead of any other clients (we always want to be behind so we can check for dups)
                         // additionally -- it should be ok to have this in the for loop because played_at will only decrease (be further in the past) so we should only hit this once, hopefully
-                        this.logger.info('Potential plays were discovered close to polling interval! Delaying scrobble clients refresh by 10 seconds so other clients have time to scrobble first');
-                        await sleep(10 * 1000);
+
+                        // make sure delay is less than possible polling interval
+                        const maxDelay = Math.min(10, interval * 0.75);
+                        this.logger.info(`Potential plays were discovered close to polling interval! Delaying scrobble clients refresh by ${maxDelay} seconds so other clients have time to scrobble first`);
+                        await sleep(maxDelay * 1000);
                     }
                     newDiscovered = this.discover(playObjs);
                     this.scrobble(newDiscovered,

--- a/src/backend/tests/ytm/ytm.test.ts
+++ b/src/backend/tests/ytm/ytm.test.ts
@@ -1,11 +1,30 @@
 import { after, before, describe, it } from 'mocha';
+import { loggerTest, loggerDebug } from "@foxxmd/logging";
 import chai, { assert, expect } from 'chai';
 import asPromised from 'chai-as-promised';
-import { Innertube, UniversalCache, Parser, YTNodes, IBrowseResponse } from 'youtubei.js';
-import { ytiHistoryResponseFromShelfToPlays, ytiHistoryResponseToListItems } from "../../sources/YTMusicSource.js";
-import ytHistoryRes from './ytres.json';
+import clone from "clone";
+import YTMusicSource, { ytiHistoryResponseFromShelfToPlays, ytiHistoryResponseToListItems } from "../../sources/YTMusicSource.js";
+import ytHistoryRes from './ytres.json' assert {type: 'json'};
+import EventEmitter from "events";
+import { generatePlay, generatePlays } from '../utils/PlayTestUtils.js';
+import { YTMusicSourceConfig } from '../../common/infrastructure/config/source/ytmusic.js';
 
 chai.use(asPromised);
+
+const createYtSource = (opts?: {
+    config?: YTMusicSourceConfig
+    emitter?: EventEmitter
+}) => {
+    const {
+        config = {
+            options: {
+                logDiff: true
+            }
+        },
+        emitter = new EventEmitter
+    } = opts || {};
+    return new YTMusicSource('test', config, { localUrl: new URL('https://example.com'), configDir: 'fake', logger: loggerDebug, version: 'test' }, emitter);
+}
 
 describe('Parses History', function () {
 
@@ -17,5 +36,64 @@ describe('Parses History', function () {
     it(`Parses a history response plays with shelf name`, async function () {
         const items = ytiHistoryResponseFromShelfToPlays(ytHistoryRes);
         expect(items[0]?.meta?.comment).to.eq('March 2023');
+    });
+});
+
+describe('Handles temporal inconsistency in history', function () {
+
+    it(`Adds new, prepended track`, async function () {
+
+        const source = createYtSource();
+
+        const plays = [...generatePlays(10, {}, { comment: 'Today' }), ...generatePlays(10, {}, { comment: 'Yesterday' })];
+
+        expect(source.parseRecentAgainstResponse(plays)).length(20);
+
+        source.polling = true;
+
+        expect(source.parseRecentAgainstResponse(plays)).length(0);
+
+        const prependedPlays = [generatePlay({}, { comment: 'Today' }), ...plays];
+
+        expect(source.parseRecentAgainstResponse(prependedPlays)).length(1);
+
+        expect(source.parseRecentAgainstResponse(prependedPlays)).length(0);
+    });
+
+    it(`Adds bumped, prepended track`, async function () {
+
+        const source = createYtSource();
+
+        const plays = [...generatePlays(10, {}, { comment: 'Today' }), ...generatePlays(10, {}, { comment: 'Yesterday' })];
+
+        expect(source.parseRecentAgainstResponse(plays)).length(20);
+
+        source.polling = true;
+
+        expect(source.parseRecentAgainstResponse(plays)).length(0);
+
+        const bumpedList = [...plays.map(x => clone(x))];
+        const bumped = bumpedList[6];
+        bumpedList.splice(6, 1);
+        bumpedList.unshift(bumped);
+
+        expect(source.parseRecentAgainstResponse(bumpedList)).length(1);
+    });
+
+    it(`Does not add appended track`, async function () {
+
+        const source = createYtSource();
+
+        const plays = [...generatePlays(10, {}, { comment: 'Today' }), ...generatePlays(10, {}, { comment: 'Yesterday' })];
+
+        expect(source.parseRecentAgainstResponse(plays)).length(20);
+
+        source.polling = true;
+
+        expect(source.parseRecentAgainstResponse(plays)).length(0);
+
+        const appendPlays = [...plays.slice(1), generatePlay({}, { comment: 'Yesterday' })];
+
+        expect(source.parseRecentAgainstResponse(appendPlays)).length(0);
     });
 });

--- a/src/backend/tests/ytm/ytm.test.ts
+++ b/src/backend/tests/ytm/ytm.test.ts
@@ -48,17 +48,22 @@ describe('Handles temporal inconsistency in history', function () {
 
         const plays = [...generatePlays(10, {}, { comment: 'Today' }), ...generatePlays(10, {}, { comment: 'Yesterday' })];
 
-        expect(source.parseRecentAgainstResponse(plays)).length(20);
+        // emulating init, get history to use as base truth without discovering tracks
+        expect(source.parseRecentAgainstResponse(plays).plays).length(20);
 
         source.polling = true;
 
-        expect(source.parseRecentAgainstResponse(plays)).length(0);
+        // first true poll emulating no new tracks played (should not add new tracks from base truth)
+        expect(source.parseRecentAgainstResponse(plays).plays).length(0);
 
+        // add new track played
         const prependedPlays = [generatePlay({}, { comment: 'Today' }), ...plays];
+        const prependResult = source.parseRecentAgainstResponse(prependedPlays);
+        expect(prependResult.plays).length(1);
+        expect(prependResult).to.deep.include({consistent: true, diffType: 'added'});
+        expect(prependResult.diffResults[2]).eq('prepend');
 
-        expect(source.parseRecentAgainstResponse(prependedPlays)).length(1);
-
-        expect(source.parseRecentAgainstResponse(prependedPlays)).length(0);
+        expect(source.parseRecentAgainstResponse(prependedPlays).plays).length(0);
     });
 
     it(`Adds bumped, prepended track`, async function () {
@@ -67,18 +72,24 @@ describe('Handles temporal inconsistency in history', function () {
 
         const plays = [...generatePlays(10, {}, { comment: 'Today' }), ...generatePlays(10, {}, { comment: 'Yesterday' })];
 
-        expect(source.parseRecentAgainstResponse(plays)).length(20);
+        // emulating init, get history to use as base truth without discovering tracks
+        expect(source.parseRecentAgainstResponse(plays).plays).length(20);
 
         source.polling = true;
 
-        expect(source.parseRecentAgainstResponse(plays)).length(0);
+        // first true poll emulating no new tracks played (should not add new tracks from base truth)
+        expect(source.parseRecentAgainstResponse(plays).plays).length(0);
 
+        // add new track played that was seen in base truth (YT *bumps* track from earlier position to top of list)
         const bumpedList = [...plays.map(x => clone(x))];
         const bumped = bumpedList[6];
         bumpedList.splice(6, 1);
         bumpedList.unshift(bumped);
 
-        expect(source.parseRecentAgainstResponse(bumpedList)).length(1);
+        const bumpedResults = source.parseRecentAgainstResponse(bumpedList);
+        expect(bumpedResults.plays).length(1);
+        expect(bumpedResults).to.deep.include({consistent: true, diffType: 'bump'});
+        expect(bumpedResults.diffResults[2]).eq('prepend');
     });
 
     it(`Does not add appended track`, async function () {
@@ -87,15 +98,20 @@ describe('Handles temporal inconsistency in history', function () {
 
         const plays = [...generatePlays(10, {}, { comment: 'Today' }), ...generatePlays(10, {}, { comment: 'Yesterday' })];
 
-        expect(source.parseRecentAgainstResponse(plays)).length(20);
+        // emulating init, get history to use as base truth without discovering tracks
+        expect(source.parseRecentAgainstResponse(plays).plays).length(20);
 
         source.polling = true;
 
-        expect(source.parseRecentAgainstResponse(plays)).length(0);
+        // first true poll emulating no new tracks played (should not add new tracks from base truth)
+        expect(source.parseRecentAgainstResponse(plays).plays).length(0);
 
+        // track is erroneously added to end of history ("new" track played in the past, not temporally consistent)
         const appendPlays = [...plays.slice(1), generatePlay({}, { comment: 'Yesterday' })];
-
-        expect(source.parseRecentAgainstResponse(appendPlays)).length(0);
+        const appenedResult =source.parseRecentAgainstResponse(appendPlays);
+        expect(appenedResult.plays).length(0);
+        expect(appenedResult).to.deep.include({consistent: false, diffType: 'added'});
+        expect(appenedResult.diffResults[2]).eq('append');
     });
 
     it(`Detects outdated recent history when order was previously seen`, async function () {
@@ -106,28 +122,38 @@ describe('Handles temporal inconsistency in history', function () {
 
         const plays = [...generatePlays(10, {}, { comment: 'Today' }), ...generatePlays(10, {}, { comment: 'Yesterday' })];
 
-        expect(source.parseRecentAgainstResponse(plays)).length(20);
+        // emulating init, get history to use as base truth without discovering tracks
+        expect(source.parseRecentAgainstResponse(plays).plays).length(20);
 
         source.polling = true;
 
-        expect(source.parseRecentAgainstResponse(plays)).length(0);
+        // first true poll emulating no new tracks played (should not add new tracks from base truth)
+        expect(source.parseRecentAgainstResponse(plays).plays).length(0);
 
+        // add new track played
         const newPlay = generatePlay({}, { comment: 'Today' });
-
         const prependedPlays = [newPlay, ...plays];
-
-        expect(source.parseRecentAgainstResponse(prependedPlays)).length(1);
+        expect(source.parseRecentAgainstResponse(prependedPlays).plays).length(1);
 
         await sleep(1000);
 
-        expect(source.parseRecentAgainstResponse(plays)).length(0);
+        // YT returns outdated history
+        // should be detected as append since "removed" track in last position from previous history is seen again
+        const badAppend = source.parseRecentAgainstResponse(plays);
+        expect(badAppend).to.deep.include({consistent: false, diffType: 'added', plays: []});
+        expect(badAppend.diffResults[2]).eq('append');
 
         await sleep(500);
 
-        expect(source.parseRecentAgainstResponse(plays)).length(0);
+        // contiuned outdated history
+        expect(source.parseRecentAgainstResponse(plays)).to.deep.include({consistent: true, plays: []});
 
         await sleep(500);
 
-        expect(source.parseRecentAgainstResponse(prependedPlays)).length(0);
+        // correct, current history is finally returned correctly
+        const recentHistoryResult = source.parseRecentAgainstResponse(prependedPlays);
+        expect(recentHistoryResult).to.deep.include({consistent: false, plays: []});
+        // should detect that we have seen this history before and not duplicate add already discovered tracks
+        expect(recentHistoryResult.reason).includes('(Add Plays Detected) YTM History has exact order as another recent response *where history was changed*')
     });
 });

--- a/src/backend/utils/PlayComparisonUtils.ts
+++ b/src/backend/utils/PlayComparisonUtils.ts
@@ -176,7 +176,7 @@ export const playsAreBumpedOnly = (aPlays: PlayObject[], bPlays: PlayObject[], t
 export const humanReadableDiff = (aPlay: PlayObject[], bPlay: PlayObject[], result: ListDiff): string => {
     const changes: [string, string?][] = [];
     for(const [index, play] of bPlay.entries()) {
-        const ab: [string, string?] = [`${index + 1}. ${buildTrackString(play, {include: ['artist', 'track', 'trackId', 'album']})}`];
+        const ab: [string, string?] = [`${index + 1}. ${buildTrackString(play, {include: ['artist', 'track', 'trackId', 'album', 'comment']})}`];
 
         const isEqual = result.diff.some(x => x.status === 'equal' && x.prevIndex === index && x.newIndex === index);
         if(!isEqual) {

--- a/src/backend/utils/PlayComparisonUtils.ts
+++ b/src/backend/utils/PlayComparisonUtils.ts
@@ -66,7 +66,14 @@ export const getDiffIndexState = (results: any, index: number) => {
     return undefined;
 }
 
-export const playsAreAddedOnly = (aPlays: PlayObject[], bPlays: PlayObject[], transformers: ListTransformers = defaultListTransformers): [boolean, PlayObject[]?, ('append' | 'prepend' | 'insert')?] => {
+export type PlayOrderBumpedType = 'append' | 'prepend';
+export type PlayOrderAddedType = PlayOrderBumpedType | 'insert';
+export type PlayOrderChangeType = PlayOrderAddedType | PlayOrderBumpedType;
+
+
+export type PlayOrderConsistencyResults<T extends PlayOrderChangeType> = [boolean, PlayObject[]?, T?]
+
+export const playsAreAddedOnly = (aPlays: PlayObject[], bPlays: PlayObject[], transformers: ListTransformers = defaultListTransformers): PlayOrderConsistencyResults<PlayOrderAddedType> => {
     const results = getPlaysDiff(aPlays, bPlays, transformers);
      if(results.status === 'equal' || results.status === 'deleted') {
         return [false];
@@ -117,7 +124,7 @@ export const playsAreAddedOnly = (aPlays: PlayObject[], bPlays: PlayObject[], tr
     return [addType !== 'insert' && addType !== undefined, added.map(x => bPlays[x.newIndex]), addType];
 }
 
-export const playsAreBumpedOnly = (aPlays: PlayObject[], bPlays: PlayObject[], transformers: ListTransformers = defaultListTransformers): [boolean, PlayObject[]?, ('append' | 'prepend')?] => {
+export const playsAreBumpedOnly = (aPlays: PlayObject[], bPlays: PlayObject[], transformers: ListTransformers = defaultListTransformers): PlayOrderConsistencyResults<PlayOrderBumpedType> => {
     const results = getPlaysDiff(aPlays, bPlays, transformers);
     if(results.status === 'equal' || results.status === 'deleted') {
        return [false];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

* Use diff change type to restrict type of diff results allowed for YTM history changes -- only allow when add/bump diffs are prepend ("new" tracks at top of history list)
* Store some (4) recent history responses where order changed. Then, on add-prepend diffs check that a previous response does not exactly match. If it does this is probably an indicator a "newer" response actually has outdated data (#227) and we should ignore new tracks
* Add tests for YTM history processing to test all of the above
* Use shelf-playlist response instead of flat list when parsing plays so we preserve playlist name
  * Print playlist name to diff debug for more context when troubleshooting logs
* Detect skipped plays based on reasonable time elapsed since last discovered track (#226)
  * Newest track is always added as it could be playing now, n+1 tracks are added based on cumulative elapsed - duration
* Interim, discovered tracks are given play date based on now - cumulative duration of all prior interim tracks 

## Issue number and link, if applicable

#227 
#228 
#226