### PR TITLE
fix(plex): Improve handling of orphaned API sessions

### DIFF
--- a/src/backend/sources/PlayerState/PlexPlayerState.ts
+++ b/src/backend/sources/PlayerState/PlexPlayerState.ts
@@ -7,7 +7,7 @@ import { PositionalPlayerState } from "./PositionalPlayerState.js";
 export class PlexPlayerState extends PositionalPlayerState {
     constructor(logger: Logger, platformId: PlayPlatformId, opts?: PlayerStateOptions) {
         super(logger, platformId, {allowedDrift: 17000, rtTruth: true, ...(opts || {})});
-
+        this.gracefulEndBuffer = this.allowedDrift / 1000;
     }
 
     protected isSessionStillPlaying(position: number): boolean {

--- a/src/backend/sources/PlayerState/PositionalPlayerState.ts
+++ b/src/backend/sources/PlayerState/PositionalPlayerState.ts
@@ -12,6 +12,7 @@ export class PositionalPlayerState extends AbstractPlayerState {
 
     protected allowedDrift: number;
     protected rtTruth: boolean;
+    protected gracefulEndBuffer: number = 3;
 
     declare currentListenRange?: ListenRangePositional;
     declare listenRanges: ListenRangePositional[];
@@ -83,13 +84,13 @@ export class PositionalPlayerState extends AbstractPlayerState {
         if (this.currentListenRange !== undefined && this.currentListenRange.getDuration() !== 0) {
             this.logger.debug('Ended current Player listen range.')
             let finalPosition: number;
-            if(this.calculatedStatus === CALCULATED_PLAYER_STATUSES.playing && !this.currentListenRange.isInitial()) {
+            if([CALCULATED_PLAYER_STATUSES.playing, CALCULATED_PLAYER_STATUSES.stale].includes(this.calculatedStatus) && !this.currentListenRange.isInitial()) {
                 const {
                     data: {
                         duration,
                     } = {}
                 } = this.currentPlay;
-                if(duration !== undefined && (duration - this.currentListenRange.end.position) < 3) {
+                if(duration !== undefined && (duration - this.currentListenRange.end.position) < this.gracefulEndBuffer) {
                     // likely the track was listened to until it ended
                     // but polling interval or network delays caused MS to not get data on the very end
                     // also...within 3 seconds of ending is close enough to call this complete IMO

--- a/src/backend/sources/PlexApiSource.ts
+++ b/src/backend/sources/PlexApiSource.ts
@@ -408,6 +408,10 @@ export default class PlexApiSource extends MemoryPositionalSource {
     sessionToPlayerState = (obj: GetSessionsMetadata): PlayerStateDataMaybePlay => {
 
         const {
+            // represents milliseconds position of player
+            // * only available when player is PLAYING (not paused)
+            // * when user seeks or pauses/stops -> plays the initial position is accurate
+            //   * when playing, is only updated every 15 seconds from the position of play
             viewOffset,
             player: {
                 machineIdentifier,


### PR DESCRIPTION
- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

* Do play cleanup during polling for new plays so that we can discover tracks from abandoned players
* Fixes missed scrobbles from Plex API when Source stops returning a session due to player queue end
* Makes grace period for final range larger to compensate for plex api position coarseness (fixed non-100% listened scrobble)

## Issue number and link, if applicable

#223 
