### PR TITLE
fix(spotify): Generate played object from cleanup with correct TS

### DIFF
--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -105,7 +105,8 @@ export default class MemorySource extends AbstractSource {
         // if we haven't already tried to discover any in-progress plays then do it now (and only once)
         if(!this.playerCleanupDiscoveryAttempt.has(key)) {
             this.playerCleanupDiscoveryAttempt.set(key, true);
-            const cleanupPlay = player.getPlayedObject();
+            // get play as completed
+            const cleanupPlay = player.getPlayedObject(true);
             let discoverablePlay: boolean;
             if(cleanupPlay !== undefined) {
                 const [discoverable, discoverableReason] = this.isListenedPlayDiscoverable(cleanupPlay);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

Add missing arg to pass to `getPlayedObject` to ensure the timestamp used for `playDate` is the same as normally discovered tracks. Without the arg two tracks played, with the latter being scrobbled on stale, would cause the latter to have the same TS as the former due to the former using end-of-play TS and the latter using first-seen-at TS (which would be the same)

## Issue number and link, if applicable

#254 