### PR TITLE
feat(source): Stale/orphan scrobble and timestamp improvments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,7 @@
         "eslint": "^8.56.0",
         "eslint-plugin-prefer-arrow-functions": "^3.2.4",
         "mocha": "^10.3.0",
+        "mockdate": "^3.0.5",
         "msw": "^2.1.2",
         "nodemon": "^3.0.3",
         "ts-essentials": "^9.1.2",
@@ -7392,6 +7393,12 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "node_modules/mopidy": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-prefer-arrow-functions": "^3.2.4",
     "mocha": "^10.3.0",
+    "mockdate": "^3.0.5",
     "msw": "^2.1.2",
     "nodemon": "^3.0.3",
     "ts-essentials": "^9.1.2",

--- a/src/backend/common/infrastructure/config/common.ts
+++ b/src/backend/common/infrastructure/config/common.ts
@@ -48,5 +48,32 @@ export interface PollingOptions {
      * @examples [30]
      * */
     maxInterval?: number
+
+    /**
+     * Number of seconds after which A Player is considered Stale
+     * 
+     * When Polling the source does not recieve data about a specific Player after X seconds it becomes Stale. When the Player becomes Stale:
+     * 
+     * * The current listening session is ended. If the Player becomes active again a new listening session is started (Player will miss `interval` seconds of listening)
+     * * If the player has an existing session w/ track then MS attempts to scrobble it
+     * 
+     * This option DOES NOT need to be set. It is automatically calculated as (`interval` * 3) when not defined.
+     */
+    staleAfter?: number
+
+    /**
+     * Number of seconds after which A Player is considered Orphaned
+     * 
+     * When Polling the source does not recieve data about a specific Player after X seconds it becomes Orphaned. When the Player becomes Orphaned:
+     * 
+     * * The current Player session is ended and the Player is removed from MS
+     * * MS attempts to scrobble, if the Player has an existing session w/ track
+     * 
+     * A Player should become Orphaned EQUAL TO OR AFTER it becomes Stale.
+     * 
+     * * This option DOES NOT need to be set. It is automatically calculated as (`interval` * 5) when not defined.
+     * * If it is set it must be equal to or larger than `staleAfter` or (`interval * 3`)
+     */
+     orphanedAfter?: number
 }
 

--- a/src/backend/sources/AbstractSource.ts
+++ b/src/backend/sources/AbstractSource.ts
@@ -33,7 +33,7 @@ import {
     sortByNewestPlayDate,
     sortByOldestPlayDate,
 } from "../utils.js";
-import { comparePlayTemporally, temporalAccuracyIsAtLeast, todayAwareFormat } from "../utils/TimeUtils.js";
+import { comparePlayTemporally, temporalAccuracyIsAtLeast, timeToHumanTimestamp, todayAwareFormat } from "../utils/TimeUtils.js";
 import { getRoot } from '../ioc.js';
 import { componentFileLogger } from '../common/logging.js';
 import { WebhookPayload } from '../common/infrastructure/config/health/webhooks.js';
@@ -440,6 +440,8 @@ export default abstract class AbstractSource extends AbstractComponent implement
 
                 const activeThreshold = this.lastActivityAt.add(checkActiveFor, 's');
                 const inactiveFor = dayjs.duration(Math.abs(activeThreshold.diff(dayjs(), 'millisecond'))).humanize(false);
+                const relativeActivity = dayjs.duration(this.lastActivityAt.diff(dayjs(), 'ms'));
+                const humanRelativeActivity = relativeActivity.asSeconds() > -3 ? '' : ` (${timeToHumanTimestamp(relativeActivity)} ago)`;
                 let friendlyInterval = '';
                 const friendlyLastFormat = todayAwareFormat(this.lastActivityAt);
                 if (activeThreshold.isBefore(dayjs())) {
@@ -452,12 +454,12 @@ export default abstract class AbstractSource extends AbstractComponent implement
                         sleepTime = interval + backoff;
                     }
                     if(isDebugMode()) {
-                        debugMsgs.push(`Last activity ${friendlyLastFormat} is ${inactiveFor} outside of polling period (last activity + ${checkActiveFor}s)`);
+                        debugMsgs.push(`Last activity ${friendlyLastFormat}${humanRelativeActivity} is ${inactiveFor} outside of polling period (last activity + ${checkActiveFor}s)`);
                     } else {
-                        debugMsgs.push(`Last activity was at ${friendlyLastFormat}`);
+                        debugMsgs.push(`Last activity was at ${friendlyLastFormat}${humanRelativeActivity}`);
                     }
                 } else {
-                    debugMsgs.push(`Last activity was at ${friendlyLastFormat}`);
+                    debugMsgs.push(`Last activity was at ${friendlyLastFormat}${humanRelativeActivity}`);
                     friendlyInterval = `${formatNumber(sleepTime)}s`;
                 }
                 debugMsgs.push(`Next check in ${friendlyInterval}`);

--- a/src/backend/sources/JellyfinSource.ts
+++ b/src/backend/sources/JellyfinSource.ts
@@ -14,9 +14,9 @@ import {
     doubleReturnNewline,
     isDebugMode,
     parseBool,
-    parseDurationFromTimestamp,
     playObjDataMatch,
 } from "../utils.js";
+import { parseDurationFromTimestamp } from '../utils/TimeUtils.js';
 import {
     comparePlayTemporally,
     temporalAccuracyIsAtLeast,

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -141,7 +141,7 @@ export default class MemorySource extends AbstractSource {
 
     setNewPlayer = (idStr: string, logger: Logger, id: PlayPlatformId, opts: PlayerStateOptions = {}) => {
         this.players.set(idStr, this.getNewPlayer(this.logger, id, {
-            ...createPlayerOptions(this.config.data as Partial<PollingOptions>),
+            ...createPlayerOptions(this.config.data as Partial<PollingOptions>, this.playerSourceOfTruth, this.logger),
             ...opts
         }));
         this.playerState.set(idStr, '');

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -116,6 +116,14 @@ export default class MemorySource extends AbstractSource {
                 }
                 if(discoverable) {
                     discoveredCleanupPlay = cleanupPlay;
+                    // we are discovering/scrobbling play 
+                    // and since player is now stale we should treat this "session" as ended
+                    // -- so if user resumes a stale play later its a new session (new real time period of them listening)
+                    // basically this is the same as if the player was orphaned and removed
+                    // 
+                    // so we remove listen ranges so the old accumulated listen time can't be used for the "new" listening session
+                    player.listenRanges = [];
+                    player.currentListenRange = undefined;
                 }
             }
         }

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -1,5 +1,5 @@
 import { Logger } from "@foxxmd/logging";
-import dayjs from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
 import { EventEmitter } from "events";
 import objectHash from 'object-hash';
 import { SimpleIntervalJob, Task, ToadScheduler } from "toad-scheduler";
@@ -184,7 +184,7 @@ export default class MemorySource extends AbstractSource {
         return sessions[0];
     }
     
-    processRecentPlays = (datas: (PlayObject | PlayerStateDataMaybePlay)[]) => {
+    processRecentPlays = (datas: (PlayObject | PlayerStateDataMaybePlay)[], reportedTS?: Dayjs) => {
 
         const {
             options: {
@@ -239,7 +239,7 @@ export default class MemorySource extends AbstractSource {
                     playerState.position = playerState.play.meta?.trackProgressPosition;
                 }
 
-                const [currPlay, prevPlay] = player.update(playerState);
+                const [currPlay, prevPlay] = player.update(playerState, reportedTS);
                 const candidate = prevPlay !== undefined ? prevPlay : currPlay;
                 const playChanged = prevPlay !== undefined;
 

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -27,7 +27,7 @@ import {
     playObjDataMatch,
     thresholdResultSummary,
 } from "../utils.js";
-import { timePassesScrobbleThreshold } from "../utils/TimeUtils.js";
+import { timePassesScrobbleThreshold, timeToHumanTimestamp } from "../utils/TimeUtils.js";
 import AbstractSource from "./AbstractSource.js";
 import { AbstractPlayerState, createPlayerOptions, PlayerStateOptions } from "./PlayerState/AbstractPlayerState.js";
 import { GenericPlayerState } from "./PlayerState/GenericPlayerState.js";
@@ -120,7 +120,7 @@ export default class MemorySource extends AbstractSource {
             }
         }
         if(deletePlayer) {
-            this.deletePlayer(player.platformIdStr, `Removed after being orphaned for ${dayjs.duration(player.stateIntervalOptions.orphanedInterval, 'seconds').asMinutes()} minutes`);
+            this.deletePlayer(player.platformIdStr, `Removed after being orphaned for ${timeToHumanTimestamp(dayjs.duration(player.stateIntervalOptions.orphanedInterval, 'seconds'))}`);
         }
 
         return discoveredCleanupPlay;

--- a/src/backend/sources/PlayerState/AbstractPlayerState.ts
+++ b/src/backend/sources/PlayerState/AbstractPlayerState.ts
@@ -102,18 +102,18 @@ export abstract class AbstractPlayerState {
         return this.platformId[0] === candidateId[0] && this.platformId[1] === candidateId[1];
     }
 
-    isUpdateStale() {
+    isUpdateStale(reportedTS?: Dayjs) {
         if (this.currentPlay !== undefined) {
-            return Math.abs(dayjs().diff(this.playLastUpdatedAt, 'seconds')) > this.stateIntervalOptions.staleInterval;
+            return Math.abs((reportedTS ?? dayjs()).diff(this.playLastUpdatedAt, 'seconds')) > this.stateIntervalOptions.staleInterval;
         }
         return false;
     }
 
-    checkStale() {
-        const isStale = this.isUpdateStale();
+    checkStale(reportedTS?: Dayjs) {
+        const isStale = this.isUpdateStale(reportedTS);
         if (isStale && ![CALCULATED_PLAYER_STATUSES.stale, CALCULATED_PLAYER_STATUSES.orphaned].includes(this.calculatedStatus)) {
             this.calculatedStatus = CALCULATED_PLAYER_STATUSES.stale;
-            this.logger.debug(`Stale after no Play updates for ${timeToHumanTimestamp(Math.abs(dayjs().diff(this.playLastUpdatedAt, 'ms')))} (staleAfter ${this.stateIntervalOptions.staleInterval}s)`);
+            this.logger.debug(`Stale after no Play updates for ${timeToHumanTimestamp(Math.abs((reportedTS ?? dayjs()).diff(this.playLastUpdatedAt, 'ms')))} (staleAfter ${this.stateIntervalOptions.staleInterval}s)`);
             // end current listening sessions
             this.currentListenSessionEnd();
         }
@@ -170,7 +170,7 @@ export abstract class AbstractPlayerState {
 
     protected setPlay(state: PlayerStateData, reportedTS?: Dayjs): [PlayObject, PlayObject?] {
         const {play, status, sessionId} = state;
-        this.playLastUpdatedAt = dayjs();
+        this.playLastUpdatedAt = reportedTS ?? dayjs();
         if (status !== undefined) {
             this.reportedStatus = status;
         }
@@ -344,7 +344,7 @@ export abstract class AbstractPlayerState {
         const {play, position} = state;
 
         this.currentPlay = play;
-        this.playFirstSeenAt = dayjs();
+        this.playFirstSeenAt = reportedTS ?? dayjs();
         this.listenRanges = [];
         this.currentListenRange = undefined;
 

--- a/src/backend/sources/PlayerState/AbstractPlayerState.ts
+++ b/src/backend/sources/PlayerState/AbstractPlayerState.ts
@@ -16,7 +16,7 @@ import { PollingOptions } from "../../common/infrastructure/config/common.js";
 import { formatNumber, genGroupIdStr, playObjDataMatch, progressBar } from "../../utils.js";
 import { ListenProgress } from "./ListenProgress.js";
 import { ListenRange, ListenRangePositional } from "./ListenRange.js";
-import { todayAwareFormat } from "../../utils/TimeUtils.js";
+import { timeToHumanTimestamp, todayAwareFormat } from "../../utils/TimeUtils.js";
 
 export interface PlayerStateIntervals {
     staleInterval?: number
@@ -113,7 +113,7 @@ export abstract class AbstractPlayerState {
         const isStale = this.isUpdateStale();
         if (isStale && ![CALCULATED_PLAYER_STATUSES.stale, CALCULATED_PLAYER_STATUSES.orphaned].includes(this.calculatedStatus)) {
             this.calculatedStatus = CALCULATED_PLAYER_STATUSES.stale;
-            this.logger.debug(`Stale after no Play updates for ${Math.abs(dayjs().diff(this.playLastUpdatedAt, 'seconds'))} seconds`);
+            this.logger.debug(`Stale after no Play updates for ${timeToHumanTimestamp(Math.abs(dayjs().diff(this.playLastUpdatedAt, 'ms')))} (staleAfter ${this.stateIntervalOptions.staleInterval}s)`);
             // end current listening sessions
             this.currentListenSessionEnd();
         }
@@ -132,7 +132,7 @@ export abstract class AbstractPlayerState {
         const isOrphaned = this.isOrphaned();
         if (isOrphaned && this.calculatedStatus !== CALCULATED_PLAYER_STATUSES.orphaned) {
             this.calculatedStatus = CALCULATED_PLAYER_STATUSES.orphaned;
-            this.logger.debug(`Orphaned after no player updates for ${Math.abs(dayjs().diff(this.stateLastUpdatedAt, 'minutes'))} minutes`);
+            this.logger.debug(`Orphaned after no Player updates for ${timeToHumanTimestamp(Math.abs(dayjs().diff(this.stateLastUpdatedAt, 'ms')))} ${Math.abs(dayjs().diff(this.stateLastUpdatedAt, 'minutes'))} (orhanedAfter ${this.stateIntervalOptions.orphanedInterval}s)`);
         }
         return isOrphaned;
     }

--- a/src/backend/tests/source/TestSource.ts
+++ b/src/backend/tests/source/TestSource.ts
@@ -1,8 +1,18 @@
 import { PlayObject } from "../../../core/Atomic.js";
 import AbstractSource from "../../sources/AbstractSource.js";
+import { MemoryPositionalSource } from "../../sources/MemoryPositionalSource.js";
+import MemorySource from "../../sources/MemorySource.js";
 
 export class TestSource extends AbstractSource {
     handle(plays: PlayObject[]) {
         this.scrobble(plays);
     }
+}
+
+export class TestMemorySource extends MemoryPositionalSource {
+
+}
+
+export class TestMemoryPositionalSource extends MemoryPositionalSource {
+
 }

--- a/src/backend/tests/utils/PlayTestUtils.ts
+++ b/src/backend/tests/utils/PlayTestUtils.ts
@@ -7,6 +7,7 @@ import timezone from "dayjs/plugin/timezone.js";
 import utc from "dayjs/plugin/utc.js";
 import { JsonPlayObject, ObjectPlayData, PlayMeta, PlayObject } from "../../../core/Atomic.js";
 import { sortByNewestPlayDate } from "../../utils.js";
+import { NO_DEVICE, NO_USER, PlayerStateDataMaybePlay, PlayPlatformId, ReportedPlayerStatus } from '../../common/infrastructure/Atomic.js';
 
 dayjs.extend(utc)
 dayjs.extend(isBetween);
@@ -132,6 +133,21 @@ export const normalizePlays = (plays: PlayObject[],
     }
 
     return normalizedPlays;
+}
+
+export const generatePlayerStateData = (options: Omit<PlayerStateDataMaybePlay, 'platformId'> & {playData?: ObjectPlayData, playMeta?: PlayMeta, platformId?: PlayPlatformId} = {}): PlayerStateDataMaybePlay => {
+    let play: PlayObject = options.play ?? generatePlay(options.playData, options.playMeta);
+    if(options.position !== undefined) {
+        play.meta.trackProgressPosition = options.position;
+    }
+    return {
+        platformId: options.platformId ?? [NO_DEVICE, NO_USER],
+        sessionId: options.sessionId,
+        play,
+        status: options.status,
+        position: options.position,
+        timestamp: options.timestamp ?? dayjs()
+    }
 }
 
 export const generatePlay = (data: ObjectPlayData = {}, meta: PlayMeta = {}): PlayObject => {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -230,7 +230,7 @@ export const parseRetryAfterSecsFromObj = (err: any) => {
     // }
     const {
         response: {
-            // @ts-ignore
+            // @ts-expect-error
             headers, // returned in superagent error
         } = {},
         retryAfter: ra // possible custom property we have set
@@ -300,48 +300,6 @@ export const removeUndefinedKeys = <T extends Record<string, any>>(obj: T): T | 
     });
     //Object.keys(newObj).forEach(key => newObj[key] === undefined || newObj[key] && delete newObj[key])
     return newObj;
-}
-
-export const parseDurationFromTimestamp = (timestamp: any) => {
-    if (timestamp === null || timestamp === undefined) {
-        return undefined;
-    }
-    if (!(typeof timestamp === 'string')) {
-        throw new Error('Timestamp must be a string');
-    }
-    if (timestamp.trim() === '') {
-        return undefined;
-    }
-    const parsedRuntime = timestamp.split(':');
-    let hours = '0',
-        minutes = '0',
-        seconds = '0',
-        milli = '0';
-
-    switch (parsedRuntime.length) {
-        case 3:
-            hours = parsedRuntime[0];
-            minutes = parsedRuntime[1];
-            seconds = parsedRuntime[2];
-            break;
-        case 2:
-            minutes = parsedRuntime[0];
-            seconds = parsedRuntime[1];
-            break;
-        case 1:
-            seconds = parsedRuntime[0];
-    }
-    const splitSec = seconds.split('.');
-    if (splitSec.length > 1) {
-        seconds = splitSec[0];
-        milli = splitSec[1];
-    }
-    return dayjs.duration({
-        hours: Number.parseInt(hours),
-        minutes: Number.parseInt(minutes),
-        seconds: Number.parseInt(seconds),
-        milliseconds: Number.parseInt(milli)
-    });
 }
 
 export const remoteHostIdentifiers = (req: Request): RemoteIdentityParts => {

--- a/src/backend/utils/TimeUtils.ts
+++ b/src/backend/utils/TimeUtils.ts
@@ -288,7 +288,7 @@ export const parseDurationFromTimestamp = (timestamp: any) => {
 export type Milliseconds = number;
 
 export const timeToHumanTimestamp = (val: ReturnType<typeof dayjs.duration> | Milliseconds): string => {
-    const ms = dayjs.isDuration(val) ? val.asMilliseconds() : val;
+    const ms = dayjs.isDuration(val) ? Math.abs(val.asMilliseconds()) : val;
 
     // less than one hour
     if(ms < 3600000) {

--- a/src/backend/utils/TimeUtils.ts
+++ b/src/backend/utils/TimeUtils.ts
@@ -245,4 +245,56 @@ export const todayAwareFormat = (date: Dayjs, opts: {fullFormat?: string, todayF
         todayFormat = 'HH:mm:ssZ'
     } = opts;
     return date.format(date.isToday() ? todayFormat : fullFormat);
+};
+export const parseDurationFromTimestamp = (timestamp: any) => {
+    if (timestamp === null || timestamp === undefined) {
+        return undefined;
+    }
+    if (!(typeof timestamp === 'string')) {
+        throw new Error('Timestamp must be a string');
+    }
+    if (timestamp.trim() === '') {
+        return undefined;
+    }
+    const parsedRuntime = timestamp.split(':');
+    let hours = '0', minutes = '0', seconds = '0', milli = '0';
+
+    switch (parsedRuntime.length) {
+        case 3:
+            hours = parsedRuntime[0];
+            minutes = parsedRuntime[1];
+            seconds = parsedRuntime[2];
+            break;
+        case 2:
+            minutes = parsedRuntime[0];
+            seconds = parsedRuntime[1];
+            break;
+        case 1:
+            seconds = parsedRuntime[0];
+    }
+    const splitSec = seconds.split('.');
+    if (splitSec.length > 1) {
+        seconds = splitSec[0];
+        milli = splitSec[1];
+    }
+    return dayjs.duration({
+        hours: Number.parseInt(hours),
+        minutes: Number.parseInt(minutes),
+        seconds: Number.parseInt(seconds),
+        milliseconds: Number.parseInt(milli)
+    });
+};
+
+export type Milliseconds = number;
+
+export const timeToHumanTimestamp = (val: ReturnType<typeof dayjs.duration> | Milliseconds): string => {
+    const ms = dayjs.isDuration(val) ? val.asMilliseconds() : val;
+
+    // less than one hour
+    if(ms < 3600000) {
+        // EX 14:07
+        return new Date(ms).toISOString().substring(14, 19)
+    }
+    // EX 01:15:45
+    return new Date(ms).toISOString().substring(11, 19);
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Describe your changes

* Add user configurable stale/orphaned intervals
* Clear listening progress after scrobbling stale Play to prevent excess scrobbling if Play is resumed before player is orphaned
* Improve logging timestamps for activity and stale/orphaned statements