### PR TITLE
feat: Implement dummy endpoint Sources for Listenbrainz and Last.fm

### DIFF
--- a/config/endpointlz.json.example
+++ b/config/endpointlz.json.example
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "myLz",
+    "enable": true,
+    "data": {
+      "token": "myToken"
+    }
+  }
+]

--- a/src/backend/common/infrastructure/Atomic.ts
+++ b/src/backend/common/infrastructure/Atomic.ts
@@ -15,6 +15,7 @@ export type SourceType =
     | 'jellyfin'
     | 'lastfm'
     | 'deezer'
+    | 'endpointlz'
     | 'ytmusic'
     | 'mpris'
     | 'mopidy'
@@ -35,6 +36,7 @@ export const sourceTypes: SourceType[] = [
     'jellyfin',
     'lastfm',
     'deezer',
+    'endpointlz',
     'ytmusic',
     'mpris',
     'mopidy',

--- a/src/backend/common/infrastructure/config/source/endpointlz.ts
+++ b/src/backend/common/infrastructure/config/source/endpointlz.ts
@@ -1,0 +1,32 @@
+import { CommonSourceConfig, CommonSourceData } from "./index.js";
+
+export interface ListenbrainzEndpointData extends CommonSourceData {
+    /**
+     * The URL ending that should be used to identify scrobbles for this source
+     *
+     * If you are using multiple Listenbrainz endpoint sources (scrobbles for many users) you can use a slug to match Sources with individual users/origins
+     *
+     * Example:
+     *
+     * * slug: 'usera' => API URL: http://localhost:9078/api/listenbrainz/usera
+     * * slug: 'originb' => API URL: http://localhost:9078/api/listenbrainz/originb
+     *
+     * If no slug is found from an extension's incoming webhook event the first Listenbrainz source without a slug will be used
+     * */
+    slug?: string | null
+
+    /**
+     * If an LZ submission request contains this token in the Authorization Header it will be used to match the submission with this Source
+     *
+     * See: https://listenbrainz.readthedocs.io/en/latest/users/api/index.html#add-the-user-token-to-your-requests
+     * */
+    token?: string | null
+}
+
+export interface ListenbrainzEndpointSourceConfig extends CommonSourceConfig {
+    data?: ListenbrainzEndpointData
+}
+
+export interface ListenbrainzEndpointSourceAIOConfig extends ListenbrainzEndpointSourceConfig {
+    type: 'endpointlz'
+}

--- a/src/backend/common/infrastructure/config/source/sources.ts
+++ b/src/backend/common/infrastructure/config/source/sources.ts
@@ -1,4 +1,5 @@
 import { ChromecastSourceAIOConfig, ChromecastSourceConfig } from "./chromecast.js";
+import { ListenbrainzEndpointSourceAIOConfig, ListenbrainzEndpointSourceConfig } from "./endpointlz.js";
 import { DeezerSourceAIOConfig, DeezerSourceConfig } from "./deezer.js";
 import { JellyApiSourceAIOConfig, JellyApiSourceConfig, JellySourceAIOConfig, JellySourceConfig } from "./jellyfin.js";
 import { JRiverSourceAIOConfig, JRiverSourceConfig } from "./jriver.js";
@@ -24,6 +25,7 @@ export type SourceConfig =
     | PlexApiSourceConfig
     | TautulliSourceConfig
     | DeezerSourceConfig
+    | ListenbrainzEndpointSourceConfig
     | SubSonicSourceConfig
     | JellySourceConfig
     | JellyApiSourceConfig
@@ -46,6 +48,7 @@ export type SourceAIOConfig =
     | PlexApiSourceAIOConfig
     | TautulliSourceAIOConfig
     | DeezerSourceAIOConfig
+    | ListenbrainzEndpointSourceAIOConfig
     | SubsonicSourceAIOConfig
     | JellySourceAIOConfig
     | JellyApiSourceAIOConfig

--- a/src/backend/common/vendor/ListenbrainzApiClient.ts
+++ b/src/backend/common/vendor/ListenbrainzApiClient.ts
@@ -81,7 +81,7 @@ export interface ListenPayload {
 }
 
 export interface SubmitPayload {
-    listen_type: 'single',
+    listen_type: 'single' | 'playing_now',
     payload: [ListenPayload]
 }
 
@@ -296,6 +296,43 @@ export class ListenbrainzApiClient extends AbstractApiClient {
                     release_mbid: brainz.album,
                     release_group_mbid: brainz.releaseGroup
                 }
+            }
+        }
+    }
+
+    static listenPayloadToPlay(payload: ListenPayload, nowPlaying: boolean = false): PlayObject {
+        const {
+            listened_at = dayjs().unix(),
+            track_metadata: {
+                artist_name,
+                track_name,
+                additional_info: {
+                    duration,
+                    track_mbid,
+                    artist_mbids,
+                    release_mbid,
+                    release_group_mbid
+                } = {}
+            } = {},
+        } = payload;
+
+        return {
+            data: {
+                playDate: typeof listened_at === 'number' ? dayjs.unix(listened_at) : dayjs(listened_at),
+                track: track_name,
+                artists: [artist_name],
+                duration,
+                meta: {
+                    brainz: {
+                        artist: artist_mbids !== undefined ? artist_mbids : undefined,
+                        album: release_mbid,
+                        albumArtist: release_group_mbid,
+                        track: track_mbid
+                    }
+                }
+            },
+            meta: {
+                nowPlaying,
             }
         }
     }

--- a/src/backend/server/api.ts
+++ b/src/backend/server/api.ts
@@ -24,6 +24,7 @@ import { parseBool, sortByNewestPlayDate } from "../utils.js";
 import { setupAuthRoutes } from "./auth.js";
 import { setupDeezerRoutes } from "./deezerRoutes.js";
 import { setupJellyfinRoutes } from "./jellyfinRoutes.js";
+import {setupLZEndpointRoutes} from "./endpointListenbrainzRoutes.js";
 import { makeClientCheckMiddle, makeSourceCheckMiddle } from "./middleware.js";
 import { setupPlexRoutes } from "./plexRoutes.js";
 import { setupTautulliRoutes } from "./tautulliRoutes.js";
@@ -152,6 +153,7 @@ export const setupApi = (app: ExpressWithAsync, logger: Logger, appLoggerStream:
     setupJellyfinRoutes(app, logger, scrobbleSources);
     setupDeezerRoutes(app, logger, scrobbleSources);
     setupWebscrobblerRoutes(app, logger, scrobbleSources);
+    setupLZEndpointRoutes(app, logger, scrobbleSources);
     setupAuthRoutes(app, logger, sourceRequiredMiddle, clientRequiredMiddle, scrobbleSources, scrobbleClients);
 
     app.putAsync('/api/webscrobbler', bodyParser.json({type: ['text/*', 'application/json']}), async (req, res) => {

--- a/src/backend/server/endpointListenbrainzRoutes.ts
+++ b/src/backend/server/endpointListenbrainzRoutes.ts
@@ -2,7 +2,7 @@
 import { ExpressWithAsync } from "@awaitjs/express";
 import { childLogger, Logger } from "@foxxmd/logging";
 import bodyParser from "body-parser";
-import { EndpointListenbrainzSource, playStateFromRequest } from "../sources/EndpointListenbrainzSource.js";
+import { EndpointListenbrainzSource, playStateFromRequest, parseDisplayIdentifiersFromRequest } from "../sources/EndpointListenbrainzSource.js";
 import { LZEndpointNotifier } from "../sources/ingressNotifiers/LZEndpointNotifier.js";
 import ScrobbleSources from "../sources/ScrobbleSources.js";
 import { nonEmptyBody } from "./middleware.js";
@@ -17,7 +17,7 @@ export const setupLZEndpointRoutes = (app: ExpressWithAsync, parentLogger: Logge
     const nonEmptyCheck = nonEmptyBody(logger, 'LZ Endpoint');
 
     const webhookIngress = new LZEndpointNotifier(logger);
-    app.useAsync(/\/api\/listenbrainz.*/,
+    app.useAsync(/(\/api\/listenbrainz.*)|(\/1\/submit-listens)/,
         async function (req, res, next) {
             // track request before parsing body to ensure we at least log that something is happening
             // (in the event body parsing does not work or request is not POST/PATCH)
@@ -40,7 +40,7 @@ export const setupLZEndpointRoutes = (app: ExpressWithAsync, parentLogger: Logge
 
             const validSources = sources.filter(x => x.matchRequest(req));
             if (validSources.length === 0) {
-                const [slug, token] = EndpointListenbrainzSource.parseDisplayIdentifiersFromRequest(req);
+                const [slug, token] = parseDisplayIdentifiersFromRequest(req);
                 logger.warn(`No Listenbrainz endpoint config matched => Slug: ${slug} | Token: ${token}`);
             }
 

--- a/src/backend/sources/EndpointListenbrainzSource.ts
+++ b/src/backend/sources/EndpointListenbrainzSource.ts
@@ -1,0 +1,191 @@
+import dayjs from "dayjs";
+import EventEmitter from "events";
+import { PlayObject, SOURCE_SOT } from "../../core/Atomic.js";
+import {
+    ExpressRequest,
+    FormatPlayObjectOptions,
+    InternalConfig,
+    NO_USER,
+    PlayerStateData,
+    REPORTED_PLAYER_STATUSES,
+    ReportedPlayerStatus
+} from "../common/infrastructure/Atomic.js";
+import { ListenbrainzEndpointSourceConfig } from "../common/infrastructure/config/source/endpointlz.js";
+import { ListenbrainzApiClient, ListenPayload, SubmitPayload } from "../common/vendor/ListenbrainzApiClient.js";
+import { parseRegexSingleOrFail } from "../utils.js";
+import MemorySource from "./MemorySource.js";
+
+const noSlugMatch = new RegExp(/\/api\/listenbrainz(?:\/?|\/1\/?|\/1\/submit-listens\/?)$/i);
+const slugMatch = new RegExp(/\/api\/listenbrainz\/([^\/]+)(?:\/?|\/1\/?|\/1\/submit-listens\/?)$/i);
+
+export const authHeaderRegex = new RegExp(/Token (.+)$/i);
+
+export class EndpointListenbrainzSource extends MemorySource {
+
+    declare config: ListenbrainzEndpointSourceConfig;
+
+    constructor(name: any, config: ListenbrainzEndpointSourceConfig, internal: InternalConfig, emitter: EventEmitter) {
+        super('endpointlz', name, config, internal, emitter);
+        this.multiPlatform = true;
+        this.playerSourceOfTruth = SOURCE_SOT.HISTORY;
+
+        const {
+            data = {},
+            data: {
+                slug,
+            } = {}
+        } = this.config;
+        this.config.data = {
+            token: undefined,
+            ...data,
+            slug: slug === null ? undefined : slug,
+        };
+    }
+
+    static parseSlugFromString(path: string): string | false | undefined {
+        const noSlug = parseRegexSingleOrFail(noSlugMatch, path);
+        if (noSlug !== undefined) {
+            return undefined;
+        }
+        const slugResult = parseRegexSingleOrFail(slugMatch, path);
+        if (slugResult !== undefined) {
+            return slugResult.groups[0];
+        }
+        return false;
+    }
+
+    static parseSlugFromRequest(req: ExpressRequest): string | false | undefined {
+        return EndpointListenbrainzSource.parseSlugFromString(req.baseUrl);
+    }
+
+    static parseTokenFromString(str: string): string | undefined {
+        const tokenMatch = parseRegexSingleOrFail(authHeaderRegex, str);
+        if(tokenMatch !== undefined) {
+            return tokenMatch.groups[0];
+        }
+        return undefined;
+    }
+
+    static parseTokenFromRequest(req: ExpressRequest): string | false | undefined {
+        const auth = req.header('Authorization');
+        if(typeof auth === 'string' && auth !== '') {
+            const matchedToken = EndpointListenbrainzSource.parseTokenFromString(auth);
+            if(matchedToken === undefined) {
+                return false;
+            }
+            return matchedToken;
+        }
+        return undefined;
+    }
+
+    static parseIdentifiersFromRequest(req: ExpressRequest): [string | false | undefined, false | string | undefined] {
+        const slug = EndpointListenbrainzSource.parseSlugFromRequest(req);
+        const token = EndpointListenbrainzSource.parseTokenFromRequest(req);
+
+        return [slug, token];
+    }
+
+    static parseDisplayIdentifiersFromRequest(req: ExpressRequest): [string, string] {
+        const [slug, token] = EndpointListenbrainzSource.parseIdentifiersFromRequest(req);
+        let slugStr = '(no slug)';
+        if (slug === false) {
+            slugStr = '(invalid slug)';
+        } else if (slug !== undefined) {
+            slugStr = slug;
+        }
+
+        let tokenStr = '(no token)';
+        if (token === false) {
+            tokenStr = '(invalid token)';
+        } else if (token !== undefined) {
+            tokenStr = `${token.substring(0,3)}****`
+        }
+        return [slugStr, tokenStr];
+    }
+
+    matchRequest(req: ExpressRequest): boolean {
+        let matchesToken = this.config.data.token === undefined;
+        const reqToken = EndpointListenbrainzSource.parseTokenFromRequest(req);
+        if (reqToken === false) {
+            return false;
+        }
+        matchesToken = this.config.data.token === undefined && reqToken === undefined ||
+            (reqToken !== undefined && this.config.data.token !== undefined
+                && this.config.data.token.toLowerCase().trim() === reqToken.toLowerCase().trim());
+
+        if (!matchesToken) {
+            return false;
+        }
+
+        let matchesPath = false;
+        const slug = EndpointListenbrainzSource.parseSlugFromRequest(req);
+        if (slug === false) {
+            return false;
+        } else {
+            matchesPath = (this.config.data.slug === undefined && slug === undefined) || (slug !== undefined && this.config.data.slug !== undefined && this.config.data.slug.toLowerCase().trim() === slug.toLocaleLowerCase().trim());
+        }
+
+        return matchesToken && matchesPath;
+    }
+
+    static listenTypeAsPlayerStatus(event: string): ReportedPlayerStatus {
+        switch (event) {
+            case 'single':
+            case 'playing_now':
+                return REPORTED_PLAYER_STATUSES.playing;
+            default:
+                return REPORTED_PLAYER_STATUSES.unknown;
+        }
+    }
+
+    static formatPlayObj(obj: ListenPayload, options: FormatPlayObjectOptions & {
+        nowPlaying?: boolean
+    } = {}): PlayObject {
+        return ListenbrainzApiClient.listenPayloadToPlay(obj, options.nowPlaying);
+    }
+
+    getRecentlyPlayed = async (options = {}) => {
+        return this.getFlatRecentlyDiscoveredPlays();
+    }
+
+    isValidScrobble = (playObj: PlayObject) => {
+        return true;
+    }
+
+    handle = async (stateData: PlayerStateData) => {
+
+        this.processRecentPlays([stateData]);
+
+        if (stateData.play.meta.nowPlaying === false && this.isValidScrobble(stateData.play)) {
+            const discovered = this.discover([stateData.play]);
+            if (discovered.length > 0) {
+                this.scrobble(discovered);
+            }
+        }
+    }
+}
+
+export const playStateFromRequest = (obj: SubmitPayload): PlayerStateData => {
+    const {
+        listen_type,
+        payload,
+    } = obj;
+
+    const play = ListenbrainzApiClient.listenPayloadToPlay(payload[0], listen_type === 'playing_now');
+    return {
+        platformId: [play.meta.deviceId, NO_USER],
+        play,
+        status: listenTypeAsPlayerStatus(listen_type),
+        timestamp: dayjs()
+    }
+}
+
+export const listenTypeAsPlayerStatus = (event: string): ReportedPlayerStatus => {
+    switch (event) {
+        case 'single':
+        case 'playing_now':
+            return REPORTED_PLAYER_STATUSES.playing;
+        default:
+            return REPORTED_PLAYER_STATUSES.unknown;
+    }
+}

--- a/src/backend/sources/ingressNotifiers/LZEndpointNotifier.ts
+++ b/src/backend/sources/ingressNotifiers/LZEndpointNotifier.ts
@@ -1,0 +1,46 @@
+import { Logger } from "@foxxmd/logging";
+import { Request } from "express";
+import { EndpointListenbrainzSource } from "../EndpointListenbrainzSource.js";
+import { IngressNotifier } from "./IngressNotifier.js";
+
+export class LZEndpointNotifier extends IngressNotifier {
+
+    constructor(logger: Logger) {
+        super('Listenbrainz Endpoint', logger);
+    }
+
+    seenSlugs: Record<string, boolean> = {};
+    notifyBySource(req: Request, isRaw: boolean): [boolean, (string | undefined)] {
+
+        if(!isRaw) {
+
+            const [slug, token] = EndpointListenbrainzSource.parseIdentifiersFromRequest(req);
+            if(slug === false) {
+                return [false, `Request URL was not a valid: ${req.baseUrl}`];
+            }
+            const slugStr = slug ?? '(no slug)';
+
+            if(token === false) {
+                return [false, `Request URL was valid and 'Authorization' header was present but invalid. Authorization header should be 'Token tokenValue' but was '${req.header('Authorization')}'`];
+            }
+            const tokenStr = token ?? '(no token)';
+            const redactedToken = token !== undefined ? `${(token as string).substring(0,3)}****` : '(no token)';
+
+            const identifier = `${slugStr}-${tokenStr}`;
+
+            if(this.seenSlugs[identifier] === undefined) {
+                this.seenSlugs[identifier] = true;
+                return [true, `Received a well formed request to endpoint with -- Slug: ${slugStr} | Token: ${redactedToken} -- for the first time.`];
+            }
+        }
+
+        return [true, undefined];
+    }
+
+    notifyByRequest(req: Request, isRaw: boolean): string | undefined {
+        if(req.method !== 'POST') {
+            return `Expected POST request (submit-listen payload) but received ${req.method}`;
+        }
+        return;
+    }
+}

--- a/src/backend/sources/ingressNotifiers/LZEndpointNotifier.ts
+++ b/src/backend/sources/ingressNotifiers/LZEndpointNotifier.ts
@@ -1,6 +1,6 @@
 import { Logger } from "@foxxmd/logging";
 import { Request } from "express";
-import { EndpointListenbrainzSource } from "../EndpointListenbrainzSource.js";
+import { EndpointListenbrainzSource, parseIdentifiersFromRequest } from "../EndpointListenbrainzSource.js";
 import { IngressNotifier } from "./IngressNotifier.js";
 
 export class LZEndpointNotifier extends IngressNotifier {
@@ -14,9 +14,9 @@ export class LZEndpointNotifier extends IngressNotifier {
 
         if(!isRaw) {
 
-            const [slug, token] = EndpointListenbrainzSource.parseIdentifiersFromRequest(req);
+            const [slug, token] = parseIdentifiersFromRequest(req);
             if(slug === false) {
-                return [false, `Request URL was not a valid: ${req.baseUrl}`];
+                return [false, `Request URL was not valid: ${req.baseUrl}`];
             }
             const slugStr = slug ?? '(no slug)';
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Describe your changes

Implement Sources that accept standard Listenbrainz and Last.fm scrobble payloads.

- [x] Implement Listenbrainz endpoint Source
  - [x] Allow "auth" (matching source) by sent `Authentication` header token
  - [x] User configurable url slugs to support multiple LZ endpoint Sources
  - [x] Shim for standard LZ url (`mydomain.com/1/submit-listens`) for compatibility
- [ ] Implement Lastfm endpoint Source
  - [ ] Allow "auth" (matching source) by sent signed request
  - [ ] User configurable url slugs to support multiple LFM endpoint Sources (no auth needed)
  - [ ] Shim for standard LZ url (`mydomain.com/2.0/`) for compatibility

## Issue number and link, if applicable

#204