### PR TITLE
feat: Track if play is a repeat and use in duplicate scrobble detecti…

### DIFF
--- a/src/backend/scrobblers/AbstractScrobbleClient.ts
+++ b/src/backend/scrobblers/AbstractScrobbleClient.ts
@@ -539,6 +539,11 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
             // in which case we can check the scrobble api response against recent scrobbles (also from api) for a more accurate comparison
             const referenceApiScrobbleResponse = existingDataSubmitted.length > 0 ? existingDataSubmitted[0].scrobble : undefined;
 
+            // only check for fuzzy if we know this play is NOT a repeat
+            // otherwise we may get a false positive on the previously played track ending time == repeat start time
+            // -- this is info we only know if play was generated from MS player so we can be reasonably sure
+            const looseTimeAccuracy = playObj.data.repeat ? [TA_DURING] : [TA_FUZZY, TA_DURING];
+
             existingScrobble = this.recentScrobbles.find((xPre) => {
 
                 const x = this.transformPlay(xPre, TRANSFORM_HOOK.existing);
@@ -550,7 +555,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                 let timeMatch = 0;
                 if(hasAcceptableTemporalAccuracy(temporalComparison.match)) {
                     timeMatch = 1;
-                } else if(hasAcceptableTemporalAccuracy(temporalComparison.match, [TA_FUZZY, TA_DURING])) {
+                } else if(hasAcceptableTemporalAccuracy(temporalComparison.match, looseTimeAccuracy)) {
                     timeMatch = 0.6;
                 }
 

--- a/src/backend/sources/PlayerState/AbstractPlayerState.ts
+++ b/src/backend/sources/PlayerState/AbstractPlayerState.ts
@@ -75,6 +75,7 @@ export abstract class AbstractPlayerState {
     currentPlay?: PlayObject
     playFirstSeenAt?: Dayjs
     playLastUpdatedAt?: Dayjs
+    isRepeatPlay?: boolean = false;
     currentListenRange?: ListenRange
     listenRanges: ListenRange[] = [];
     createdAt: Dayjs = dayjs();
@@ -181,6 +182,7 @@ export abstract class AbstractPlayerState {
                 this.logger.debug(`Incoming play state (${buildTrackString(play, {include: ['trackId', 'artist', 'track']})}) does not match existing state, removing existing: ${buildTrackString(this.currentPlay, {include: ['trackId', 'artist', 'track']})}`)
                 this.currentListenSessionEnd();
                 const played = this.getPlayedObject(true);
+                this.isRepeatPlay = false;
                 this.setCurrentPlay(state, {reportedTS});
                 if (this.calculatedStatus !== CALCULATED_PLAYER_STATUSES.playing) {
                     this.calculatedStatus = CALCULATED_PLAYER_STATUSES.unknown;
@@ -194,6 +196,7 @@ export abstract class AbstractPlayerState {
                 this.currentListenSessionEnd();
                 const played = this.getPlayedObject(true);
                 play.data.playDate = dayjs();
+                this.isRepeatPlay = true;
                 this.setCurrentPlay(state, {reportedTS});
                 return [this.getPlayedObject(), played];
             } else {
@@ -212,6 +215,7 @@ export abstract class AbstractPlayerState {
                 this.currentListenSessionContinue(state.position, reportedTS);
             }
         } else {
+            this.isRepeatPlay = false;
             this.setCurrentPlay(state);
             this.calculatedStatus = CALCULATED_PLAYER_STATUSES.unknown;
         }
@@ -231,6 +235,7 @@ export abstract class AbstractPlayerState {
         this.playFirstSeenAt = undefined;
         this.listenRanges = [];
         this.currentListenRange = undefined;
+        this.isRepeatPlay = false;
     }
 
     protected stopPlayer() {
@@ -255,7 +260,8 @@ export abstract class AbstractPlayerState {
                     playDate: this.playFirstSeenAt,
                     listenedFor: this.getListenDuration(),
                     listenRanges: ranges,
-                    playDateCompleted: completed ? dayjs() : undefined
+                    playDateCompleted: completed ? dayjs() : undefined,
+                    repeat: this.isRepeatPlay
                 },
                 meta: this.currentPlay.meta
             }

--- a/src/backend/tests/scrobbler/scrobblers.test.ts
+++ b/src/backend/tests/scrobbler/scrobblers.test.ts
@@ -246,6 +246,23 @@ describe('Detects duplicate and unique scrobbles from client recent history', fu
 
                 assert.isFalse(await testScrobbler.alreadyScrobbled(ballad2));
             });
+
+            it('Is not detected as duplicate when play date matches fuzzy but play is marked as repeat', async function () {
+
+                const recent = normalizePlays(normalizedWithDur, {
+                    initialDate: firstPlayDate,
+                    defaultMeta: {source: 'jellyfin'}
+                });
+                testScrobbler.recentScrobbles = recent;
+
+                const repeatPlay = clone(recent[recent.length - 1]);
+                repeatPlay.data.playDate = repeatPlay.data.playDate.add(repeatPlay.data.duration + 2, 's');
+
+                assert.isTrue(await testScrobbler.alreadyScrobbled(repeatPlay));
+
+                repeatPlay.data.repeat = true;
+                assert.isFalse(await testScrobbler.alreadyScrobbled(repeatPlay));
+            });
         });
 
     });

--- a/src/core/Atomic.ts
+++ b/src/core/Atomic.ts
@@ -106,6 +106,7 @@ export interface PlayData extends TrackData {
     listenedFor?: number
     listenRanges?: ListenRangeData[]
     playDateCompleted?: Dayjs | string
+    repeat?: boolean
 }
 
 export interface PlayMeta {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Describe your changes

* Use MS Player to mark Play as a repeat if session repeat is detected
* Remove FUZZY temporal accuracy as acceptable for detecting duplicate if candidate play is marked as repeat

## Issue number and link, if applicable

#318 