### PR TITLE
fix: parse and use the tags in Apprise config

### DIFF
--- a/src/backend/notifier/AppriseWebhookNotifier.ts
+++ b/src/backend/notifier/AppriseWebhookNotifier.ts
@@ -27,12 +27,14 @@ export class AppriseWebhookNotifier extends AbstractWebhookNotifier {
 
     urls: string[];
     keys: string[];
+    tags: string[];
 
     constructor(defaultName: string, config: AppriseConfig, logger: Logger) {
         super('Apprise', defaultName, config, logger);
         const {
             urls = [],
             keys = [],
+            tags = [],
             host,
         } = this.config;
         if (host === undefined) {
@@ -40,6 +42,7 @@ export class AppriseWebhookNotifier extends AbstractWebhookNotifier {
         }
         this.urls = Array.isArray(urls) ? urls : [urls];
         this.keys = Array.isArray(keys) ? keys : [keys];
+        this.tags = Array.isArray(tags) ? tags : [tags];
 
         if (this.urls.length === 0 && this.keys.length === 0) {
             this.logger.warn(`No 'urls' or 'keys' were defined! Will assume stateless (POST ${host}/notify) and that you have the ENV 'APPRISE_STATELESS_URLS' set on your Apprise instance`);
@@ -85,6 +88,7 @@ export class AppriseWebhookNotifier extends AbstractWebhookNotifier {
         const body: Record<string, any> = {
             title: payload.title,
             body: payload.message,
+            tags: this.tags.join(','), // a comma 'OR's the tags https://github.com/caronc/apprise-api?tab=readme-ov-file#persistent-stateful-storage-solution
             type: convertPriorityToType(payload.priority)
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

The `tags` field in the AppriseConfig was not being used anywhere. I've added the parsing of this field, as well as the insertion of the value into the body sent to the apprise-api. The AppriseConfig can specify a string if the user wants to differentiate between `AND`ing and `OR`ing the tags. Otherwise, if they pass an array of tags, they will be joined by commas so they will be `OR`ed, which I think would be the expected behavior in that case.

The user can set `tags: "all"` if they want to trigger all their tagged notifications.

## Issue number and link, if applicable

context: https://github.com/FoxxMD/multi-scrobbler/issues/294#issuecomment-3046050200