### PR TITLE
feat(listenbrainz): add source as music service name

### DIFF
--- a/src/backend/common/vendor/ListenbrainzApiClient.ts
+++ b/src/backend/common/vendor/ListenbrainzApiClient.ts
@@ -696,6 +696,7 @@ export const playToListenPayload = (play: PlayObject): ListenPayload => {
                 mediaPlayerName,
                 mediaPlayerVersion,
                 musicService,
+                source
             }
         } = play;
         // using submit-listens exmaple from openapi https://rain0r.github.io/listenbrainz-openapi/index.html#/lbCore/submitListens
@@ -714,6 +715,7 @@ export const playToListenPayload = (play: PlayObject): ListenPayload => {
             media_player: mediaPlayerName ?? msAdditionalInfo.media_player,
             media_player_version: mediaPlayerVersion ?? msAdditionalInfo.media_player_version,
             music_service: musicService !== undefined ? musicServiceToCononical(musicService) : msAdditionalInfo.music_service,
+            music_service_name: source,
             spotify_id: spotify.track ?? msAdditionalInfo.spotify_id,
             spotify_album_id: spotify.album ?? msAdditionalInfo.spotify_album_id,
             spotify_artist_ids: spotify.artist ?? msAdditionalInfo.spotify_artist_ids

--- a/src/backend/tests/listenbrainz/listenbrainz.test.ts
+++ b/src/backend/tests/listenbrainz/listenbrainz.test.ts
@@ -185,4 +185,13 @@ describe('Listenbrainz Endpoint Behavior', function() {
         
     });
 
+    it('Should set music_service_name from source', function() {
+
+        const play = generatePlay({artists: ['Artist A'], albumArtists: []}, {source: 'Plex'});
+        const submitPayload = playToListenPayload(play);
+
+        expect(submitPayload.track_metadata.additional_info.music_service_name).to.be.eql('Plex')
+        
+    });
+
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Describe your changes

I added music_service_name field to the ListenBrainz submission payload. According to the [docs](https://listenbrainz.readthedocs.io/en/latest/users/json.html#id1) it's just a name to represents the service when there's no canonical domain. My reasoning behind this addition is that it would be nice to be able to identify the source of the scrobble even if it's not a know service name to Listenbrainz. I figured we could just use the multi-scrobbler source for that

Let me know if that works for you or if you have any thoughts/concerns :) 

