### PR TITLE
Make simple plex conn check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "tsx": "^4.7.0",
         "typeson": "^9.0.4",
         "typeson-registry": "^11.1.1",
+        "undici": "^7.0.0",
         "vite-express": "^0.16.0",
         "vlc-client": "^1.1.1",
         "xml2js": "0.6.1",
@@ -11376,8 +11377,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
       "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "tsx": "^4.7.0",
     "typeson": "^9.0.4",
     "typeson-registry": "^11.1.1",
+    "undici": "^7.0.0",
     "vite-express": "^0.16.0",
     "vlc-client": "^1.1.1",
     "xml2js": "0.6.1",

--- a/src/backend/sources/PlexApiSource.ts
+++ b/src/backend/sources/PlexApiSource.ts
@@ -1,24 +1,20 @@
 import EventEmitter from "events";
 import { PlayObject } from "../../core/Atomic.js";
-import { buildTrackString, combinePartsToString, truncateStringToLength } from "../../core/StringUtils.js";
+import { combinePartsToString, truncateStringToLength } from "../../core/StringUtils.js";
 import {
     asPlayerStateDataMaybePlay,
     FormatPlayObjectOptions,
     InternalConfig,
-    NO_USER,
-    PlayerStateData,
     PlayerStateDataMaybePlay,
     PlayPlatformId, REPORTED_PLAYER_STATUSES
 } from "../common/infrastructure/Atomic.js";
-import { genGroupIdStr, getFirstNonEmptyString, getPlatformIdFromData, isDebugMode, parseBool, } from "../utils.js";
+import { getFirstNonEmptyString, isDebugMode, } from "../utils.js";
 import { buildStatePlayerPlayIdententifyingInfo, hashObject, parseArrayFromMaybeString } from "../utils/StringUtils.js";
 import { GetSessionsMetadata } from "@lukehagar/plexjs/sdk/models/operations/getsessions.js";
 import { PlexAPI, HTTPClient, Fetcher } from "@lukehagar/plexjs";
 import { Agent } from 'undici';
 import { PlexApiSourceConfig } from "../common/infrastructure/config/source/plex.js";
-import { isPortReachable, joinedUrl } from '../utils/NetworkUtils.js';
-import normalizeUrl from 'normalize-url';
-import { GetTokenDetailsResponse, GetTokenDetailsUserPlexAccount } from '@lukehagar/plexjs/sdk/models/operations/gettokendetails.js';
+import { GetTokenDetailsUserPlexAccount } from '@lukehagar/plexjs/sdk/models/operations/gettokendetails.js';
 import { parseRegexSingle } from '@foxxmd/regex-buddy-core';
 import { Readable } from 'node:stream';
 import { PlexPlayerState } from './PlayerState/PlexPlayerState.js';
@@ -41,8 +37,6 @@ export default class PlexApiSource extends MemoryPositionalSource {
     plexUser: string;
 
     deviceId: string;
-
-    address: URL;
 
     usersAllow: string[] = [];
     usersBlock: string[] = [];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

Fixes an issue with the plex connection check that would not work for me under v0.10.0 and plex URL setting similar to `https://myplex.homelab.test`. This is solved by simply avoiding to parse the URL altogether and checks connectivity by getting the server capabilities.


Test docker image available at `ghcr.io/janw/multi-scrobbler:simple-plex-conn-check` and verified to be working in my setup.
