### PR TITLE
fix(spotify): Don't report player state if spotify api doesn't return an item

### DIFF
--- a/src/backend/sources/SpotifySource.ts
+++ b/src/backend/sources/SpotifySource.ts
@@ -406,7 +406,7 @@ export default class SpotifySource extends MemoryPositionalSource {
                     progress_ms,
                 } = {}
             } = res;
-            if(device !== undefined) {
+            if(device !== undefined && item !== undefined && item !== null) {
                 let status: ReportedPlayerStatus = 'stopped';
                 if(is_playing) {
                     status = 'playing';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

* fixes crash when trying to generate a play id due to spotify not returning an item

## Issue number and link, if applicable

#412