### PR TITLE
feat(tealfm): Write MusicBrainz IDs for artists

### DIFF
--- a/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
+++ b/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
@@ -61,7 +61,12 @@ export const playToRecord = (play: PlayObject): ScrobbleRecord => {
     const record: ScrobbleRecord = {
         $type: "fm.teal.alpha.feed.play",
         trackName: play.data.track,
-        artists: play.data.artists.map(x => ({ artistName: x })),
+        artists: play.data.artists.map((x, i) => ({
+            artistName: x,
+            ...(play.data.meta?.brainz?.artist?.[i]
+                ? { artistMbId: play.data.meta.brainz.artist[i] }
+                : {})
+        })),
         duration: Math.round(play.data.duration),
         playedTime: getScrobbleTsSOCDateWithContext(play)[0].toISOString(),
         releaseName: play.data.album,
@@ -116,4 +121,3 @@ export const recordToPlay = (record: ScrobbleRecord, options: RecordOptions = {}
     return play;
 };
 export const ATPROTO_URI_REGEX = new RegExp(/at:\/\/(?<resource>(?<did>did.*?)\/fm.teal.alpha.feed.play\/(?<tid>.*))/);
-


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Describe your changes

This updates the teal.fm client to also write `artistMbId` alongside `artistName` as described in the [lexicon](https://tangled.org/teal.fm/teal/blob/main/lexicons/fm.teal.alpha/feed/defs.json#L83).

This assumes that the order of artists in `TrackData.artists` and `BrainzMeta.artist` are the same, which appears to be the case from the other sources I checked.

For plays with empty/unmatched `BrainzMeta.artist` items, nothing will be written.

