### PR TITLE
feat(transformers): add exclusive search by recording MBID

### DIFF
--- a/src/backend/common/transforms/MusicbrainzTransformer.ts
+++ b/src/backend/common/transforms/MusicbrainzTransformer.ts
@@ -298,14 +298,24 @@ export default class MusicbrainzTransformer extends AtomicPartsTransformer<Exter
 
         let results: IRecordingMSList;
 
-        if(play.data.isrc !== undefined) {
+        if(play.data.meta?.brainz?.track) {
+            this.logger.debug('Play has a recording MBID present, trying search using only MBID')
+            results = await this.api.searchByRecording(play, {using: ['recording_mbid']})
+            if(results.recordings.length === 0) {
+                this.logger.debug('No recording MBID matches found.')
+            }
+        } 
+
+        if((!results || results.recordings.length === 0) && play.data.isrc !== undefined) {
             this.logger.debug('Play has ISRC present, trying search using only ISRC');
             results = await this.api.searchByRecording(play, {using: ['isrc']});
             if(results.recordings.length === 0) {
-                this.logger.debug('No matches found, trying regular search');
-                results = await this.api.searchByRecording(play);
+                this.logger.debug('No ISRC matches found.');
             }
-        } else {
+        }
+
+        if(!results || results.recordings.length === 0){
+            this.logger.debug('Trying regular search')
             results = await this.api.searchByRecording(play);
         }
 

--- a/src/backend/common/vendor/musicbrainz/MusicbrainzApiClient.ts
+++ b/src/backend/common/vendor/musicbrainz/MusicbrainzApiClient.ts
@@ -39,7 +39,7 @@ export interface MusicbrainzApiClientConfig {
 export interface SearchOptions {
     escapeCharacters?: boolean
     removeCharacters?: boolean,
-    using?: ('artist' | 'album' | 'title' | 'isrc')[]
+    using?: ('artist' | 'album' | 'title' | 'isrc' | 'recording_mbid')[]
     ttl?: string,
     freetext?: boolean
 }
@@ -211,6 +211,9 @@ export class MusicbrainzApiClient extends AbstractApiClient {
             const query: Record<string, any> = {
             };
 
+            if(play.data?.meta?.brainz?.track && using.includes('recording_mbid')) {
+                query.recording_mbid = play.data.meta.brainz.track
+            }
             if(play.data.isrc !== undefined && using.includes('isrc')) {
                 query.isrc = play.data.isrc;
             }
@@ -269,6 +272,12 @@ export class MusicbrainzApiClient extends AbstractApiClient {
                         q += ' AND ';
                     }
                     q+= `isrc:${query.isrc}`;
+                }
+                if(query.recording_mbid !== undefined) {
+                    if(q !== '') {
+                        q += ' AND ';
+                    }
+                    q += `rid:"${query.recording_mbid}"`
                 }
             }
 

--- a/src/backend/tests/musicbrainz/musicbrainz.test.ts
+++ b/src/backend/tests/musicbrainz/musicbrainz.test.ts
@@ -102,6 +102,35 @@ describe('Musicbrainz API', function () {
             expect(res.recordings).to.not.be.empty;
         });
 
+        it('tries pre-regular query using only recording MBID, if present', async function (){
+            this.timeout(3500);
+
+            const play: PlayObject = {
+                data: {
+                    track: "Fake",
+                    artists: ["Fake"],
+                    album: "Fake",
+                    meta: {
+                        brainz: {
+                            track: '026fa041-3917-4c73-9079-ed16e36f20f8'
+                        }
+                    }
+                },
+                meta: {}
+            }
+            await mbTransformer.tryInitialize();
+
+            const res = await mbTransformer.getTransformerData(play, {
+                type: "musicbrainz",
+                searchWhenMissing: ["artists", "album", "title"]
+            });
+            expect(res.recordings).to.exist;
+            expect(res.recordings).to.not.be.empty;
+            expect(res.recordings[0].isrcs).to.exist;
+            expect(res.recordings[0].isrcs).to.not.be.empty;
+            expect(res.recordings[0].isrcs).to.include('GBAHT1600302');
+        })
+
         it('tries pre-regular query using only ISRC, if present', async function () {
 
             this.timeout(3500);


### PR DESCRIPTION
and relevant test case

## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Describe your changes

Adds a new condition in the musicbrainz transformer. It checks if the scrobble has a recording MBID. If so, it is used to perform a search with [rid](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Recording) and no other query parameters, before the ISRC check. I believe this should be the correct order of preference, as an included MBID would yield an exact match on the recording more accurately than an ISRC tag.

This is useful in the case that a source, such as subsonic to a listenbrainz endpoint, only sends some MBIDs instead of any ISRCs, since it allows MS to ensure the scrobble gets complete musicbrainz metadata (for example, gonic only sends release and recording MBIDs to its listenbrainz endpoint, but none for artists, so sometimes tracks with many artists can mess up the scrobble metadata).

## Issue number and link, if applicable

I probably should've made an issue first, but I was just poking around the codebase and tried out a quick solution that seems to work well in my testing.