### PR TITLE
fix: add missing undici dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "tsx": "^4.7.0",
         "typeson": "^9.0.4",
         "typeson-registry": "^11.1.1",
+        "undici": "7.10.0",
         "vite-express": "^0.16.0",
         "vlc-client": "^1.1.1",
         "xml2js": "0.6.1",
@@ -12439,8 +12440,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
       "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "tsx": "^4.7.0",
     "typeson": "^9.0.4",
     "typeson-registry": "^11.1.1",
+    "undici": "7.10.0",
     "vite-express": "^0.16.0",
     "vlc-client": "^1.1.1",
     "xml2js": "0.6.1",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes
Adds missing dependency on `undici`. Normally this being missing isn't an issue as it's listed in `package-lock.json`, but `npm prune` on Node.js 24 and above appears to remove it because it's not depended on at the top level. I think it also just makes sense to add this, as `multi-scrobbler` does depend on it: https://github.com/FoxxMD/multi-scrobbler/blob/8f66914dfb6bd9f51c07858ae99dcd32ac298c9c/src/backend/sources/PlexApiSource.ts#L17 https://github.com/FoxxMD/multi-scrobbler/blob/8f66914dfb6bd9f51c07858ae99dcd32ac298c9c/src/backend/sources/PlexApiSource.ts#L138