### PR TITLE
chore(docker): Add source OCI labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,8 @@ RUN npm run build:parallel && rm -rf node_modules && rm -rf docsite/node_modules
 
 FROM base AS app
 
+LABEL org.opencontainers.image.source="https://github.com/FoxxMD/multi-scrobbler"
+
 COPY --chown=abc:abc *.json *.js *.ts index.html ./
 COPY --chown=abc:abc patches ./patches
 COPY --from=build --chown=abc:abc /app/dist /app/dist

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -44,6 +44,8 @@ RUN npm run docs:install && npm run build && rm -rf node_modules && rm -rf docsi
 
 FROM base as app
 
+LABEL org.opencontainers.image.source="https://github.com/FoxxMD/multi-scrobbler"
+
 #COPY --chown=abc:abc package.json yarn.lock ./
 COPY --chown=abc:abc package*.json ./
 COPY --chown=abc:abc patches ./patches


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

## Describe your changes
These labels are used, among other things, by Renovate to pull changelogs/link to the upstream repository automatically (https://docs.renovatebot.com/modules/datasource/docker/). I'm not sure where/if the Alpine image is pushed, so I couldn't check that one, but the issue with the main image is that it already has some labels set from upstream:

```
$ skopeo inspect docker://ghcr.io/foxxmd/multi-scrobbler:0.11.2 | jq '.Labels."org.opencontainers.image.source"'
"https://github.com/linuxserver/docker-baseimage-debian"
```

There are some more that you might want to override as well.

## Issue number and link, if applicable

