### PR TITLE
fix(plex): Also read MBIDs from `guid` field

### DIFF
--- a/src/backend/sources/PlexApiSource.ts
+++ b/src/backend/sources/PlexApiSource.ts
@@ -36,6 +36,8 @@ const shortDeviceId = truncateStringToLength(10, '');
 
 export const LOCAL_USER = 'PLEX_LOCAL_USER';
 
+const MBID_PREFIX = "mbid://";
+
 const THUMB_REGEX = new RegExp(/\/library\/metadata\/(?<ratingkey>\d+)\/thumb\/\d+/)
 
 export default class PlexApiSource extends MemoryPositionalSource {
@@ -533,8 +535,8 @@ ${JSON.stringify(obj)}`);
     getNewPlayer = (logger: Logger, id: PlayPlatformId, opts: PlayerStateOptions) => new PlexPlayerState(logger, id, opts);
     
     getMusicBrainzId = async (ratingKey: string | undefined): Promise<string | undefined> => {
-        if (!ratingKey) {
-            return null;
+        if (ratingKey === undefined) {
+            return undefined;
         }
         
         const cachedMbId = await this.mbIdCache.get(ratingKey);
@@ -565,24 +567,44 @@ ${JSON.stringify(obj)}`);
             );
         
             const result = await request.json();
+            
+            let mbid: string | null = null;
         
             // There shouldn't be multiple metadata or GUID objects, but we return
             // the first MBID to be safe.
-            for (const metadata of result.MediaContainer.Metadata ?? []) {
-                for (const guid of metadata.Guid ?? []) {
-                    if (typeof guid.id === "string" && guid.id.startsWith("mbid://")) {
-                        const mbid = guid.id.replace("mbid://", "");
-                        
-                        await this.mbIdCache.set(ratingKey, mbid);
-                        return mbid;
+            metadataLoop: for (const metadata of result?.MediaContainer?.Metadata ?? []) {
+                this.logger.trace(`Guid: '${metadata.Guid?.map(g => g.id)?.join(", ")}', guid: '${metadata.guid}'`)
+                
+                if (Array.isArray(metadata.Guid)) {
+                    for (const guid of metadata.Guid) {
+                        if (typeof guid.id === "string" && guid.id.startsWith(MBID_PREFIX)) {
+                            mbid = guid.id.replace(MBID_PREFIX, "");
+                            break metadataLoop;
+                        }
                     }
                 }
+                
+                // Some matched items store the MBID in the `MediaContainer.Metadata.guid` field,
+                // so we check that as a fallback if there are no objects in the `Guid` field.
+                if (typeof metadata.guid === "string" && metadata.guid.startsWith(MBID_PREFIX)) {
+                    mbid = metadata.guid.replace(MBID_PREFIX, "");
+                    break metadataLoop;
+                }
             }
+            
+            this.logger.trace(`Extracted MBID: '${mbid}'`);
+            
+            await this.mbIdCache.set(ratingKey, mbid);
+            
+            if (mbid === null) {
+                return undefined
+            }
+            
+            return mbid;
         } catch (e) {
             this.logger.warn(new Error(`Failed to get MusicBrainz IDs from Plex for item ${ratingKey}`, {cause: e}));
         }
         
-        this.mbIdCache.set(ratingKey, null);
         return undefined;
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

Some items on Plex store the MBID in the `guid` field in the `Metadata` response, not in the `Guid` field. This change checks the `guid` field as a fallback if the `Guid` field is not set.

This seems to be very rare. I've only found it on one release in my library and it fixed itself after clicking "Fix Match..." and matching it again.

<details>

<summary>
Example of an item with the MBID in `guid`
</summary>

```json
{
	"MediaContainer": {
		"size": 1,
		"allowSync": true,
		"identifier": "com.plexapp.plugins.library",
		"librarySectionID": 1,
		"librarySectionTitle": "Music",
		"librarySectionUUID": "2bc6b969-87bf-4edb-a2a1-7020a3c6ef28",
		"mediaTagPrefix": "/system/bundle/media/flags/",
		"mediaTagVersion": 1770226015,
		"Metadata": [
			{
				"ratingKey": "17362",
				"key": "/library/metadata/17362",
				"parentRatingKey": "17361",
				"grandparentRatingKey": "7933",
				"guid": "mbid://9bdba80b-e67e-4397-ac61-5fd8f4f9ede9",
				"parentGuid": "mbid://1b008cf8-f669-47d8-95bf-d8218441ca06",
				"grandparentGuid": "plex://artist/602458a7a49713002de8c87c",
				"type": "track",
				"title": "Gravitate",
				"grandparentKey": "/library/metadata/7933",
				"parentKey": "/library/metadata/17361",
				"librarySectionTitle": "Music",
				"librarySectionID": 1,
				"librarySectionKey": "/library/sections/1",
				"grandparentTitle": "wishlane",
				"parentTitle": "Gravitate / Cleft",
				"summary": "",
				"index": 1,
				"parentIndex": 1,
				"userRating": 7.0,
				"viewCount": 1,
				"lastViewedAt": 1771088420,
				"lastRatedAt": 1771088452,
				"parentYear": 2026,
				"thumb": "/library/metadata/17361/thumb/1771088468",
				"parentThumb": "/library/metadata/17361/thumb/1771088468",
				"grandparentThumb": "/library/metadata/7933/thumb/1760065861",
				"duration": 120000,
				"addedAt": 1771083563,
				"updatedAt": 1771088468,
				"musicAnalysisVersion": "1",
				"Media": [
					{
						"id": 24285,
						"duration": 120000,
						"audioChannels": 2,
						"audioCodec": "flac",
						"container": "flac",
						"hasVoiceActivity": false,
						"Part": [
							{
								"id": 30624,
								"key": "/library/parts/30624/1771083193/file.flac",
								"duration": 120000,
								"file": "/data/Music/wishlane/Gravitate _ Cleft/01 - wishlane - Gravitate.flac",
								"size": 16030818,
								"container": "flac",
								"hasThumbnail": "1",
								"Stream": [
									{
										"id": 57928,
										"streamType": 2,
										"selected": true,
										"codec": "flac",
										"index": 0,
										"channels": 2,
										"bitrate": 1069,
										"albumGain": "-8.63",
										"albumPeak": "1.000000",
										"albumRange": "9.570543",
										"audioChannelLayout": "stereo",
										"bitDepth": 16,
										"gain": "-8.63",
										"loudness": "-9.37",
										"lra": "2.00",
										"peak": "1.000000",
										"samplingRate": 48000,
										"displayTitle": "FLAC (Stereo)",
										"extendedDisplayTitle": "FLAC (Stereo)"
									}
								]
							}
						]
					}
				],
				"Image": [
					{
						"alt": "Gravitate",
						"type": "coverPoster",
						"url": "/library/metadata/7933/thumb/1760065861"
					}
				],
				"Field": [
					{
						"locked": true,
						"name": "title"
					},
					{
						"locked": true,
						"name": "originalTitle"
					},
					{
						"locked": true,
						"name": "index"
					},
					{
						"locked": true,
						"name": "parentIndex"
					}
				]
			}
		]
	}
}
```

</details>

## Issue number and link, if applicable

N/A