### PR TITLE
fix(transform): guard against undefined parseRegexSingle result in artistsIgnore

### DIFF
--- a/src/backend/common/transforms/NativeTransformer.ts
+++ b/src/backend/common/transforms/NativeTransformer.ts
@@ -214,7 +214,7 @@ export const nativeParse = (play: PlayObject, options?: NativeTransformerDataStr
 
                 for(const artist of play.data.artists) {
                 
-                    const matchedIgnoreArtists = ignoreArtistsRegex.map(x => ({reg: x.toString(), res: parseRegexSingle(x, artist)})).filter(x => x !== undefined);
+                    const matchedIgnoreArtists = ignoreArtistsRegex.map(x => ({reg: x.toString(), res: parseRegexSingle(x, artist)})).filter(x => x.res !== undefined);
                     if(matchedIgnoreArtists.length > 0) {
                         logger.debug(`Will not parse artist because it matched an ignore regex:\n${matchedIgnoreArtists.map(x => `Reg: ${x.reg} => ${x.res.match}`).join('\n')}`);
                         artists.push(artist);


### PR DESCRIPTION
## Bug

When `artistsIgnore` is defined in a Native Transform config, `parseRegexSingle()` can return `undefined` for some inputs. The filter on line 217 checks `x !== undefined`, but `x` is always a `{reg, res}` object — it's `x.res` that can be `undefined`. Accessing `x.res.match` on line 219 then throws `TypeError: Cannot read properties of undefined (reading 'match')`.

## Fix

Change the filter to `x.res !== undefined` so items where `parseRegexSingle` returned undefined are properly excluded.

Closes #567