### PR TITLE
feat: Improve stale player behavior

### DIFF
--- a/src/backend/common/infrastructure/Atomic.ts
+++ b/src/backend/common/infrastructure/Atomic.ts
@@ -94,7 +94,8 @@ export interface PlayerStateDataMaybePlay {
     play?: PlayObject
     status?: ReportedPlayerStatus
     position?: number
-    timestamp?: Dayjs
+    stateUpdatedAt?: Dayjs
+    playUpdatedAt?: Dayjs
 }
 
 export const asPlayerStateData = (obj: object): obj is PlayerStateData => asPlayerStateDataMaybePlay(obj) && 'play' in obj && isPlayObject(obj.play)

--- a/src/backend/scrobblers/AbstractScrobbleClient.ts
+++ b/src/backend/scrobblers/AbstractScrobbleClient.ts
@@ -377,10 +377,19 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                 if (this.nowPlayingLastPlay !== undefined) {
 
                     for (const [platform, data] of plays) {
-                        if (platform === this.nowPlayingLastPlay.platformId) {
+                        if (platform === this.nowPlayingLastPlay.platformId
+                            // only keep using sticky platform if it hasn't gone stale/orphaned
+                            && (!(data.player.status?.stale ?? false) && !(data.player.status?.orphaned ?? false))) {
                             return data.player;
                         }
                     }
+                }
+
+                // prefer players that are not stale/orphaned
+                let preferredPlays: typeof plays = plays.filter(([platform, data]) => !(data.player.status?.stale ?? false) && !(data.player.status?.orphaned ?? false));
+                if(preferredPlays.length === 0) {
+                    // but if there are none of these then just use whatever players are on-hand
+                    preferredPlays = plays;
                 }
 
                 // otherwise sort platform alphabetically and take first

--- a/src/backend/sources/EndpointLastfmSource.ts
+++ b/src/backend/sources/EndpointLastfmSource.ts
@@ -92,7 +92,7 @@ export const playStateFromRequest = (obj: LastFMScrobbleRequestPayload): PlayerS
         platformId: [play.meta.deviceId, NO_USER],
         play,
         status: obj.method === 'track.updateNowPlaying' ? REPORTED_PLAYER_STATUSES.playing : REPORTED_PLAYER_STATUSES.unknown,
-        timestamp: dayjs()
+        stateUpdatedAt: dayjs()
     }
 }
 

--- a/src/backend/sources/EndpointListenbrainzSource.ts
+++ b/src/backend/sources/EndpointListenbrainzSource.ts
@@ -116,7 +116,7 @@ export const playStateFromRequest = (obj: SubmitPayload): PlayerStateData => {
         platformId: [play.meta.deviceId, NO_USER],
         play,
         status: listenTypeAsPlayerStatus(listen_type),
-        timestamp: dayjs()
+        stateUpdatedAt: dayjs()
     }
 }
 

--- a/src/backend/sources/JellyfinApiSource.ts
+++ b/src/backend/sources/JellyfinApiSource.ts
@@ -508,6 +508,10 @@ export default class JellyfinApiSource extends MemoryPositionalSource {
         for(const sessionData of nonMSSessions) {
             const validPlay = this.isActivityValid(sessionData[0], sessionData[1]);
             if(validPlay === true) {
+                if(isDebugMode()) {
+                    let stateIdentifyingInfo: string = genGroupIdStr(getPlatformIdFromData(sessionData[0]));
+                    this.logger.trace(`${stateIdentifyingInfo} => Activity Date ${sessionData[1].LastActivityDate} | Playback Checkin: ${sessionData[1].LastPlaybackCheckIn} `)
+                }
                 validSessions.push(sessionData[0]);
             } else if(this.logFilterFailure !== false) {
                 let stateIdentifyingInfo: string = genGroupIdStr(getPlatformIdFromData(sessionData[0]));
@@ -535,9 +539,11 @@ export default class JellyfinApiSource extends MemoryPositionalSource {
             DeviceName,
             Client,
             LastActivityDate,
+            LastPlaybackCheckIn,
             PlayState: {
                 PositionTicks,
-                IsPaused
+                IsPaused,
+                CanSeek
             }
         } = obj;
 
@@ -557,7 +563,9 @@ export default class JellyfinApiSource extends MemoryPositionalSource {
                     ...sessionPlay.meta,
                     user: UserName ?? UserId,
                     deviceId: msDeviceId,
-                    trackProgressPosition: playerPosition
+                    trackProgressPosition: playerPosition,
+                    //lastActivityDate: LastActivityDate,
+                    //lastPlaybackCheckin: LastPlaybackCheckIn
                 }
             }
 
@@ -572,11 +580,15 @@ export default class JellyfinApiSource extends MemoryPositionalSource {
             reportedStatus = IsPaused ? REPORTED_PLAYER_STATUSES.paused : REPORTED_PLAYER_STATUSES.playing;
         }
 
+        const sessionUpdatedAt = LastActivityDate !== undefined ? dayjs(LastActivityDate) : undefined;
+
         return {
             platformId: [msDeviceId, UserName ?? UserId],
             play,
             status: reportedStatus,
             position: playerPosition,
+            stateUpdatedAt: sessionUpdatedAt,
+            playUpdatedAt: sessionUpdatedAt
             //timestamp: LastActivityDate !== undefined ? dayjs(LastActivityDate) : undefined
         }
     }

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -48,6 +48,8 @@ export default class MemorySource extends AbstractSource {
     playerState: Map<string, string> = new Map();
     playerCleanupDiscoveryAttempt: Map<string, boolean> = new Map();
 
+    deceasedPlayers: Map<string, Dayjs> = new Map();
+
     scheduler: ToadScheduler = new ToadScheduler();
 
     protected isPositional: boolean = false;
@@ -196,6 +198,10 @@ export default class MemorySource extends AbstractSource {
         return this.players.has(id);
     }
 
+    isZombiePlayer = (id: string, lastUpdated: Dayjs): boolean => {
+        return this.deceasedPlayers.has(id) && this.deceasedPlayers.get(id).isSame(lastUpdated);
+    }
+
     genPlayerId = (data: PlayObject | PlayerStateDataMaybePlay): string => {
         return genGroupIdStr(getPlatformIdFromData(data));
     }
@@ -208,6 +214,7 @@ export default class MemorySource extends AbstractSource {
             this.players.get(id)?.logger.debug(reason);
         }
         using player = this.players.get(id);
+        this.deceasedPlayers.set(id, player.stateLastUpdatedAt);
         player[Symbol.dispose]();
         this.players.delete(id);
         this.playerState.delete(id);
@@ -236,6 +243,15 @@ export default class MemorySource extends AbstractSource {
             const id = getPlatformIdFromData(data);
             const idStr = this.genPlayerId(data);
             if (!this.players.has(idStr)) {
+                if(asPlayerStateDataMaybePlay(data) && data.stateUpdatedAt !== undefined) {
+                    if(this.isZombiePlayer(idStr, data.stateUpdatedAt)) {
+                        this.logger.trace(`Not creating player for ${idStr} because last state update timestamp has not changed since it was deleted.`);
+                        continue;
+                    } else {
+                        // cleaning up in case it already existed but has new timestamp
+                        this.deceasedPlayers.delete(idStr);
+                    }
+                }
                 this.setNewPlayer(idStr, this.logger, id);
 
                 if(!this.multiPlatform && this.players.size > 1) {
@@ -257,8 +273,19 @@ export default class MemorySource extends AbstractSource {
                 return player.platformEquals(id);
             });
 
-            // we've received some form of communication from the source for this player
+            let hasFreshState = false;
             if (relevantDatas.length > 0) {
+                hasFreshState = true;
+                this.lastActivityAt = dayjs();
+                incomingData = this.pickPlatformSession(relevantDatas, player);
+                if(asPlayerStateDataMaybePlay(incomingData) && incomingData.stateUpdatedAt !== undefined && player.stateLastUpdatedAt.isSame(incomingData.stateUpdatedAt)) {
+                    hasFreshState = false;
+                    player.logger.trace('Skipping update because it has the same timestamp as the previous update');
+                }
+            }
+
+            // we've received some form of communication from the source for this player
+            if (hasFreshState) {
                 this.lastActivityAt = dayjs();
 
                 // reset any player cleanup state since we got fresh data

--- a/src/backend/sources/PlayerState/AbstractPlayerState.ts
+++ b/src/backend/sources/PlayerState/AbstractPlayerState.ts
@@ -83,7 +83,7 @@ export abstract class AbstractPlayerState {
     currentListenRange?: ListenRange
     listenRanges: ListenRange[] = [];
     createdAt: Dayjs = dayjs();
-    stateLastUpdatedAt: Dayjs = dayjs();
+    stateLastUpdatedAt: Dayjs = dayjs(0);
 
     lastPlay?: PlayObject
     lastPlayUpdatedAt?: Dayjs

--- a/src/backend/sources/PlayerState/AbstractPlayerState.ts
+++ b/src/backend/sources/PlayerState/AbstractPlayerState.ts
@@ -171,7 +171,7 @@ export abstract class AbstractPlayerState {
     }
 
     update(state: PlayerStateDataMaybePlay, reportedTS?: Dayjs) {
-        this.stateLastUpdatedAt = dayjs();
+        this.stateLastUpdatedAt = state.stateUpdatedAt ?? dayjs();
 
         const {play, status} = state;
 
@@ -194,8 +194,8 @@ export abstract class AbstractPlayerState {
     }
 
     protected setPlay(state: PlayerStateData, reportedTS?: Dayjs): [PlayObject, PlayObject?] {
-        const {play, status, sessionId} = state;
-        this.playLastUpdatedAt = reportedTS ?? dayjs();
+        const {play, status, sessionId, playUpdatedAt} = state;
+        this.playLastUpdatedAt = reportedTS ?? playUpdatedAt ?? dayjs();
         if (status !== undefined) {
             this.reportedStatus = status;
         }
@@ -208,7 +208,7 @@ export abstract class AbstractPlayerState {
                 const played = this.getPlayedObject(true);
                 this.isRepeatPlay = false;
                 this.lastPlay = played;
-                this.lastPlayUpdatedAt = dayjs();
+                this.lastPlayUpdatedAt = playUpdatedAt ?? dayjs();
                 this.setCurrentPlay(state, {reportedTS});
                 if (this.calculatedStatus !== CALCULATED_PLAYER_STATUSES.playing) {
                     this.calculatedStatus = CALCULATED_PLAYER_STATUSES.unknown;

--- a/src/backend/sources/SpotifySource.ts
+++ b/src/backend/sources/SpotifySource.ts
@@ -520,7 +520,7 @@ export default class SpotifySource extends MemoryPositionalSource implements Pag
                         platformId: [combinePartsToString([shortDeviceId(device.id), device.name]), NO_USER],
                         status,
                         play: item !== null && item !== undefined ? SpotifySource.formatPlayObj(res.body, {newFromSource: true}) : undefined,
-                        timestamp: dayjs(timestamp),
+                        stateUpdatedAt: dayjs(timestamp),
                         position: progress_ms !== null && progress_ms !== undefined ? progress_ms / 1000 : undefined,
                     }
                 }

--- a/src/backend/sources/WebScrobblerSource.ts
+++ b/src/backend/sources/WebScrobblerSource.ts
@@ -90,7 +90,7 @@ export class WebScrobblerSource extends MemorySource {
             platformId: [play.meta.deviceId, NO_USER],
             play,
             status: WebScrobblerSource.webhookEventAsPlayerStatus(eventName),
-            timestamp: dayjs.unix(time)
+            stateUpdatedAt: dayjs.unix(time)
         }
     }
 

--- a/src/backend/tests/source/source.test.ts
+++ b/src/backend/tests/source/source.test.ts
@@ -195,7 +195,7 @@ describe('Player Cleanup', function () {
     const cleanedUpDuration = async (generateSource: (config: SourceConfig) => MemorySource) => {
         await using source = generateSource({data: {staleAfter: 21, orphanedAfter: 40}, options: {}});
         const initialDate = dayjs();
-        const initialState = generatePlayerStateData({position: 0, playData: {duration: 50}, timestamp: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
+        const initialState = generatePlayerStateData({position: 0, playData: {duration: 50}, stateUpdatedAt: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
         expect((await source.processRecentPlays([initialState])).length).to.be.eq(0);
 
         let position = 0;
@@ -207,7 +207,7 @@ describe('Player Cleanup', function () {
             timeSince += 10;
             MockDate.set(initialDate.add(position, 'seconds').toDate());
             await sleep(1);
-            const advancedState = generatePlayerStateData({play: initialState.play, timestamp: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
+            const advancedState = generatePlayerStateData({play: initialState.play, stateUpdatedAt: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
             expect((await source.processRecentPlays([advancedState])).length).to.be.eq(0);
         }
 
@@ -239,7 +239,7 @@ describe('Player Cleanup', function () {
 
         await using source = generateSource({data: {staleAfter: 21, orphanedAfter: 40}, options: {}});
         const initialDate = dayjs();
-        const initialState = generatePlayerStateData({position: 0, playData: {duration: 50}, timestamp: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
+        const initialState = generatePlayerStateData({position: 0, playData: {duration: 50}, stateUpdatedAt: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
         expect((await source.processRecentPlays([initialState])).length).to.be.eq(0);
 
         let position = 0;
@@ -251,7 +251,7 @@ describe('Player Cleanup', function () {
             timeSince += 10;
             MockDate.set(initialDate.add(position, 'seconds').toDate());
             await sleep(1);
-            const advancedState = generatePlayerStateData({play: initialState.play, timestamp: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
+            const advancedState = generatePlayerStateData({play: initialState.play, stateUpdatedAt: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
             expect((await source.processRecentPlays([advancedState])).length).to.be.eq(0);
         }
 
@@ -280,7 +280,7 @@ describe('Player Cleanup', function () {
             timeSince += 10;
             MockDate.set(initialDate.add(timeSince, 'seconds').toDate());
             await sleep(1);
-            const advancedState = generatePlayerStateData({play: initialState.play, timestamp: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
+            const advancedState = generatePlayerStateData({play: initialState.play, stateUpdatedAt: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
             expect((await source.processRecentPlays([advancedState])).length).to.be.eq(0);
         }
 
@@ -288,7 +288,7 @@ describe('Player Cleanup', function () {
         MockDate.set(initialDate.add(timeSince, 'seconds').toDate());
         await sleep(1);
         // new Play
-        const advancedState = generatePlayerStateData({timestamp: dayjs(), position: 0, status: REPORTED_PLAYER_STATUSES.playing});
+        const advancedState = generatePlayerStateData({stateUpdatedAt: dayjs(), position: 0, status: REPORTED_PLAYER_STATUSES.playing});
         // should not return play because it has only been played for ~20 seconds, less than 50% of duration
         const plays = await source.processRecentPlays([advancedState])
         expect(plays.length).to.be.eq(0);
@@ -309,7 +309,7 @@ describe('Player Cleanup', function () {
         const initialDate = dayjs();
 
         // if player incorrectly counted stale time then 30s of actual play + 20s of stale time > scrobble threshold of 50% of 90s
-        const initialState = generatePlayerStateData({position: 0, playData: {duration: 90}, timestamp: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
+        const initialState = generatePlayerStateData({position: 0, playData: {duration: 90}, stateUpdatedAt: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
         expect((await source.processRecentPlays([initialState])).length).to.be.eq(0);
 
         let position = 0;
@@ -321,7 +321,7 @@ describe('Player Cleanup', function () {
             timeSince += 10;
             MockDate.set(initialDate.add(position, 'seconds').toDate());
             await sleep(1);
-            const advancedState = generatePlayerStateData({play: initialState.play, timestamp: initialDate, position, status: REPORTED_PLAYER_STATUSES.playing});
+            const advancedState = generatePlayerStateData({play: initialState.play, stateUpdatedAt: initialDate, position, status: REPORTED_PLAYER_STATUSES.playing});
             expect((await source.processRecentPlays([advancedState])).length).to.be.eq(0);
         }
 
@@ -354,7 +354,7 @@ describe('Player Cleanup', function () {
         const initialDate = dayjs();
 
         // if player incorrectly counted stale time then 30s of actual play + 20s of stale time > scrobble threshold of 50% of 90s
-        const initialState = generatePlayerStateData({position: 0, playData: {duration: 90}, timestamp: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
+        const initialState = generatePlayerStateData({position: 0, playData: {duration: 90}, stateUpdatedAt: initialDate, status: REPORTED_PLAYER_STATUSES.playing});
         expect((await source.processRecentPlays([initialState])).length).to.be.eq(0);
 
         let position = 0;
@@ -366,7 +366,7 @@ describe('Player Cleanup', function () {
             timeSince += 10;
             MockDate.set(initialDate.add(position, 'seconds').toDate());
             await sleep(1);
-            const advancedState = generatePlayerStateData({play: initialState.play, timestamp: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
+            const advancedState = generatePlayerStateData({play: initialState.play, stateUpdatedAt: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
             expect((await source.processRecentPlays([advancedState])).length).to.be.eq(0);
         }
 
@@ -396,7 +396,7 @@ describe('Player Cleanup', function () {
             timeSince += 10;
             MockDate.set(initialDate.add(position, 'seconds').toDate());
             await sleep(1);
-            const advancedState = generatePlayerStateData({play: initialState.play, timestamp: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
+            const advancedState = generatePlayerStateData({play: initialState.play, stateUpdatedAt: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
             expect((await source.processRecentPlays([advancedState])).length).to.be.eq(0);
         }
 
@@ -404,7 +404,7 @@ describe('Player Cleanup', function () {
         MockDate.set(initialDate.add(position, 'seconds').toDate());
         await sleep(1);
         // new Play
-        const advancedState = generatePlayerStateData({timestamp: dayjs(), position: 0, status: REPORTED_PLAYER_STATUSES.playing});
+        const advancedState = generatePlayerStateData({stateUpdatedAt: dayjs(), position: 0, status: REPORTED_PLAYER_STATUSES.playing});
         // should return discovered play with ~90 seconds of duration
         const plays = await source.processRecentPlays([advancedState])
         expect(plays.length).to.be.eq(1);

--- a/src/backend/tests/source/source.test.ts
+++ b/src/backend/tests/source/source.test.ts
@@ -394,14 +394,14 @@ describe('Player Cleanup', function () {
         for(let i = 0; i < 5; i++) {
             position += 10;
             timeSince += 10;
-            MockDate.set(initialDate.add(position, 'seconds').toDate());
+            MockDate.set(initialDate.add(timeSince, 'seconds').toDate());
             await sleep(1);
             const advancedState = generatePlayerStateData({play: initialState.play, stateUpdatedAt: dayjs(), position, status: REPORTED_PLAYER_STATUSES.playing});
             expect((await source.processRecentPlays([advancedState])).length).to.be.eq(0);
         }
 
         timeSince += 10;
-        MockDate.set(initialDate.add(position, 'seconds').toDate());
+        MockDate.set(initialDate.add(timeSince, 'seconds').toDate());
         await sleep(1);
         // new Play
         const advancedState = generatePlayerStateData({stateUpdatedAt: dayjs(), position: 0, status: REPORTED_PLAYER_STATUSES.playing});

--- a/src/backend/utils/CacheUtils.ts
+++ b/src/backend/utils/CacheUtils.ts
@@ -22,7 +22,7 @@ export const rehydratePlay = (obj: AmbPlayObject): PlayObject => {
         }
     }
     if(obj.data.listenRanges !== undefined) {
-        obj.data.listenRanges = obj.data.listenRanges.map(rehydrateListenRangeData);
+        obj.data.listenRanges = obj.data.listenRanges.map(rehydrateListenRangeData).filter(x => x !== undefined);
     }
     return obj as PlayObject;
 }
@@ -30,6 +30,10 @@ export const rehydratePlay = (obj: AmbPlayObject): PlayObject => {
 // this may become problematic since we aren't re-instantiating Progress class, just implementing interface
 // but that may only be an issue if rehydrating source data which isn't in scope so far
 export const rehydrateListenRangeData = (obj: ListenRangeDataAmb): ListenRangeData => {
+    // workaround for incompatible rehydration
+    if(obj.start === undefined || obj.end === undefined) {
+        return undefined;
+    }
     return {
         start: rehydratePlayProgress(obj.start),
         end: rehydratePlayProgress(obj.end)

--- a/src/core/PlayTestUtils.ts
+++ b/src/core/PlayTestUtils.ts
@@ -157,7 +157,7 @@ export const generatePlayerStateData = (options: Omit<PlayerStateDataMaybePlay, 
         play,
         status: options.status,
         position: options.position,
-        timestamp: options.timestamp ?? dayjs()
+        stateUpdatedAt: options.stateUpdatedAt ?? dayjs()
     }
 }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Describe your changes

* Utilize source update timestamps, if available, to determine if a memory player should be updated
  * Skip updates if timestamp has not changed
  * Prevent players from being re-created by comparing update timestamp at time of deletion with "new", incoming player states
* Don't use sticky now playing data if the associated player is stale/orphaned
* When multiple players are present for now playing selection, prefer those that are not stale/orphaned

## Issue number and link, if applicable

