### PR TITLE
chore: Remove references to KOITO_ALLOWED_HOSTS

### DIFF
--- a/docsite/docs/configuration/clients/koito.mdx
+++ b/docsite/docs/configuration/clients/koito.mdx
@@ -45,7 +45,7 @@ Using the URL path `/apis/listenbrainz` [Koito docs describe](https://koito.io/g
 
 :::tip
 
-Ensure that Koito is configured to allow requests from multi-scrobbler! In Koito config set [`KOITO_ALLOWED_HOSTS`](https://koito.io/reference/configuration/#koito_allowed_hosts) to the IP the multi-scrobbler dashboard is accessible from.
+For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `https://koito.mydomain.com`. 
 
 :::
 

--- a/docsite/docs/configuration/clients/koito.mdx
+++ b/docsite/docs/configuration/clients/koito.mdx
@@ -45,7 +45,7 @@ Using the URL path `/apis/listenbrainz` [Koito docs describe](https://koito.io/g
 
 :::tip
 
-For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `https://koito.mydomain.com`. 
+For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `koito.mydomain.com`. 
 
 :::
 

--- a/docsite/docs/configuration/clients/koito.mdx
+++ b/docsite/docs/configuration/clients/koito.mdx
@@ -45,7 +45,7 @@ Using the URL path `/apis/listenbrainz` [Koito docs describe](https://koito.io/g
 
 :::tip
 
-For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `koito.mydomain.com`. 
+For Koito versions <=0.1.7, you must have the environment variable KOITO_ALLOWED_HOSTS set correctly in your Koito environment/container. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `koito.mydomain.com`. 
 
 :::
 

--- a/docsite/docs/quickstart.mdx
+++ b/docsite/docs/quickstart.mdx
@@ -255,7 +255,7 @@ Modify the `lastfm.json` file you created in the [Setup Sources](#setup-sources)
 
         :::tip
         
-        For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `koito.mydomain.com`. 
+        For Koito versions <=0.1.7, you must have the environment variable KOITO_ALLOWED_HOSTS set correctly in your Koito environment/container. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `koito.mydomain.com`. 
         
         :::
 

--- a/docsite/docs/quickstart.mdx
+++ b/docsite/docs/quickstart.mdx
@@ -254,9 +254,9 @@ Modify the `lastfm.json` file you created in the [Setup Sources](#setup-sources)
         ```
 
         :::tip
-
-        Ensure that Koito is configured to allow requests from multi-scrobbler! In Koito config set [`KOITO_ALLOWED_HOSTS`](https://koito.io/reference/configuration/#koito_allowed_hosts) to the IP the multi-scrobbler dashboard is accessible from.
-
+        
+        For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `https://koito.mydomain.com`. 
+        
         :::
 
     </TabItem>

--- a/docsite/docs/quickstart.mdx
+++ b/docsite/docs/quickstart.mdx
@@ -255,7 +255,7 @@ Modify the `lastfm.json` file you created in the [Setup Sources](#setup-sources)
 
         :::tip
         
-        For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `https://koito.mydomain.com`. 
+        For Koito versions <=0.1.7, you must have the environment variable `KOITO_ALLOWED_HOSTS` set correctly. Ensure it is set to the IP address or domain name that you use to access Koito with e.g. `koito.mydomain.com`. 
         
         :::
 

--- a/src/backend/common/vendor/koito/KoitoApiClient.ts
+++ b/src/backend/common/vendor/koito/KoitoApiClient.ts
@@ -118,7 +118,7 @@ export class KoitoApiClient extends AbstractApiClient implements PaginatedTimeRa
             let allowedHint = '';
             if(e.cause !== undefined && 'response' in e.cause) {
                 if(e.cause.response.status === 403) {
-                    allowedHint = ` HINT: 403 usually means Koito env KOITO_ALLOWED_HOSTS is not configured correctly to allowed requests from multi-scrobbler. Check Koito logs for warnings.`
+                    allowedHint = ` HINT: 403 usually means Koito env KOITO_ALLOWED_HOSTS is not configured correctly. Check Koito logs for warnings.`
                 }
             }
             throw new Error(`A server exists at ${this.url.url.hostname}:${this.url.port} but is not responding to API calls as expected.${allowedHint}`, { cause: e });
@@ -158,7 +158,7 @@ export class KoitoApiClient extends AbstractApiClient implements PaginatedTimeRa
 
         let resp: ListensResponse;
         try {
-        resp = await this.getUserListens({...params, page: params.cursor});    
+        resp = await this.getUserListens({...params, page: params.cursor});
     } catch (e) {
         throw new Error('Error occurred while getting Koito paginated listens', { cause: e });
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Describe your changes
Removes references to the Koito configuration option `KOITO_ALLOWED_HOSTS`, which was [removed in v0.1.8](https://github.com/gabehf/Koito/releases/tag/v0.1.8).


## Issue number and link, if applicable

