### PR TITLE
AbstractComponent: handle empty cached steps array without TypeError

### DIFF
--- a/src/backend/common/AbstractComponent.ts
+++ b/src/backend/common/AbstractComponent.ts
@@ -220,8 +220,14 @@ export default abstract class AbstractComponent extends AbstractInitializable {
                 try {
                     // only patch play if steps didn't end in a failure that we are okay with returning partial from
                     let shouldTransform = true;
-                    const lastCachedStep = cachedSteps[cachedSteps.length - 1];
-                    if(lastCachedStep.error !== undefined && lastCachedStep.flowKnownState !== 'skip' && !lastCachedStep.returnPartial) {
+                    // CoverArtArchive (and other transformers) can produce an
+                    // empty cached step list when the API returns no result;
+                    // accessing `.error` on an undefined `lastCachedStep`
+                    // crashed the whole transform stage and poisoned the
+                    // cache for the album (#578). Treat empty cached steps
+                    // as "nothing to apply" rather than throwing.
+                    const lastCachedStep = cachedSteps.length > 0 ? cachedSteps[cachedSteps.length - 1] : undefined;
+                    if(lastCachedStep !== undefined && lastCachedStep.error !== undefined && lastCachedStep.flowKnownState !== 'skip' && !lastCachedStep.returnPartial) {
                         shouldTransform = false;
                     }
 


### PR DESCRIPTION
Fixes #578.

`transformPlay` indexed `cachedSteps[cachedSteps.length - 1]` and immediately read `.error` on the result. When CoverArtArchive (or any other transformer) returns an empty step list — e.g. the MBID has no upload in the archive — the index is `-1` and the access is on `undefined`, raising `TypeError: Cannot read properties of undefined (reading 'error')`. The exception poisoned the cache for the album and silently killed every fallback transformer (Spotify) for that play.

Treat the empty list as 'nothing to apply' so the transform falls through to the next stage.