### PR TITLE
fix(webscrobbler): Convert express wildcard path to regex

### DIFF
--- a/src/backend/server/webscrobblerRoutes.ts
+++ b/src/backend/server/webscrobblerRoutes.ts
@@ -31,7 +31,7 @@ export const setupWebscrobblerRoutes = (app: Express, parentLogger: Logger, scro
     },
         cors(corsOpts));
 
-    app.post('/api/webscrobbler*path',
+    app.post(/api\/webscrobbler\/?.*/,
         async (req, res, next) => {
             webhookIngress.trackIngress(req, true);
             next();


### PR DESCRIPTION
New path wildcard from expressjs 5 doesn't seem to work. Use tried and try regex instead

Fixes #583

## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

Fix webscrobbler path to use regex instead of new wildcard path

## Issue number and link, if applicable

