### PR TITLE
feat(tealfm): Add now playing support with fm.teal.alpha.actor.status

### DIFF
--- a/src/backend/common/infrastructure/config/client/tealfm.ts
+++ b/src/backend/common/infrastructure/config/client/tealfm.ts
@@ -79,6 +79,15 @@ export interface ScrobbleRecord {
     [x: string]: unknown
 }
 
+export interface StatusRecord {
+    $type: "fm.teal.alpha.actor.status",
+    /** item is just ScrobbleRecord, but without $type */
+    item: Omit<ScrobbleRecord, '$type'>,
+    time: string,
+    expiry: string,
+    [x: string]: unknown
+}
+
 export interface ListRecord<T> {
   uri: string;
   cid: string;

--- a/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
+++ b/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
@@ -124,13 +124,16 @@ export const playToRecord = (play: PlayObject): ScrobbleRecord => {
 }
 
 export const playToStatusRecord = (play: PlayObject, notPlaying: boolean, position?: number): StatusRecord => {
-    const { $type, ...item } = playToRecord(play);
+    const { $type, ...item } = notPlaying
+        ? { trackName: "", artists: [] }
+        : playToRecord(play);
     return {
         $type: "fm.teal.alpha.actor.status",
         time: dayjs().toISOString(),
-        // expiry is 1min ago if paused, (now + duration - position) if position is available, or fallback to (now + 10mins)
+        // 1min ago if paused -> try now + (duration - position) -> try now + duration -> fallback to now + 10mins
         expiry: notPlaying ? dayjs().subtract(1, 'minute').toISOString()
-            : position !== undefined ? dayjs().add(play.data.duration - position, 'second').toISOString()
+            : position !== undefined && play.data.duration !== undefined ? dayjs().add(play.data.duration - position, 'second').toISOString()
+            : play.data.duration !== undefined ? dayjs().add(play.data.duration, 'second').toISOString()
             : dayjs().add(10, 'minute').toISOString(),
         item
     };

--- a/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
+++ b/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
@@ -8,7 +8,7 @@ import { BrainzMeta, PlayObject, SourcePlayerObj, PlayObjectLifecycleless, Scrob
 import { musicServiceToCononical } from '../listenbrainz/lzUtils.js';
 import { parseRegexSingle } from "@foxxmd/regex-buddy-core";
 import { RecordOptions } from "../../infrastructure/config/client/tealfm.js";
-import dayjs, { ManipulateType } from "dayjs";
+import dayjs, { Dayjs, ManipulateType } from "dayjs";
 import { getScrobbleTsSOCDateWithContext, usecToUnix } from "../../../utils/TimeUtils.js";
 import { removeUndefinedKeys } from "../../../utils.js";
 import { baseFormatPlayObj } from "../../../utils/PlayTransformUtils.js";
@@ -127,14 +127,22 @@ export const playToStatusRecord = (play: PlayObject, notPlaying: boolean, positi
     const { $type, ...item } = notPlaying
         ? { trackName: "", artists: [] }
         : playToRecord(play);
+
+    // default "fallback" value
+    let expiry: Dayjs = dayjs().add(10, 'minute');
+    // 1min ago if paused -> try now + (duration - position) -> try now + duration -> fallback
+    if(notPlaying) {
+        expiry = dayjs().subtract(1, 'minute');
+    } else if(position !== undefined && play.data.duration !== undefined) {
+        expiry = dayjs().add(play.data.duration - position, 'second');
+    } else if(play.data.duration !== undefined) {
+        expiry = dayjs().add(play.data.duration, 'second');
+    }
+    
     return {
         $type: "fm.teal.alpha.actor.status",
         time: dayjs().toISOString(),
-        // 1min ago if paused -> try now + (duration - position) -> try now + duration -> fallback to now + 10mins
-        expiry: notPlaying ? dayjs().subtract(1, 'minute').toISOString()
-            : position !== undefined && play.data.duration !== undefined ? dayjs().add(play.data.duration - position, 'second').toISOString()
-            : play.data.duration !== undefined ? dayjs().add(play.data.duration, 'second').toISOString()
-            : dayjs().add(10, 'minute').toISOString(),
+        expiry: expiry.toISOString(),
         item
     };
 }

--- a/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
+++ b/src/backend/common/vendor/bluesky/AbstractBlueSkyApiClient.ts
@@ -1,10 +1,10 @@
 import { getRoot } from "../../../ioc.js";
 import { AbstractApiOptions, PagelessListensTimeRangeOptions, PagelessTimeRangeListens, PagelessTimeRangeListensResult } from "../../infrastructure/Atomic.js";
-import { ListRecord, ScrobbleRecord, TealClientData } from "../../infrastructure/config/client/tealfm.js";
+import { ListRecord, ScrobbleRecord, StatusRecord, TealClientData } from "../../infrastructure/config/client/tealfm.js";
 import AbstractApiClient from "../AbstractApiClient.js";
-import { Agent, ComAtprotoRepoCreateRecord, ComAtprotoRepoListRecords } from "@atproto/api";
+import { Agent, ComAtprotoRepoCreateRecord, ComAtprotoRepoListRecords, ComAtprotoRepoPutRecord } from "@atproto/api";
 import { MSCache } from "../../Cache.js";
-import { BrainzMeta, PlayObject, PlayObjectLifecycleless, ScrobbleActionResult, UnixTimestamp } from "../../../../core/Atomic.js";
+import { BrainzMeta, PlayObject, SourcePlayerObj, PlayObjectLifecycleless, ScrobbleActionResult, UnixTimestamp } from "../../../../core/Atomic.js";
 import { musicServiceToCononical } from '../listenbrainz/lzUtils.js';
 import { parseRegexSingle } from "@foxxmd/regex-buddy-core";
 import { RecordOptions } from "../../infrastructure/config/client/tealfm.js";
@@ -45,6 +45,21 @@ export abstract class AbstractBlueSkyApiClient extends AbstractApiClient impleme
             return {payload: input, response: resp.data};
         } catch (e) {
             throw new ScrobbleSubmitError(`Failed to create record for scrobble`, { cause: e, payload: input, response: 'response' in e ? e.response : undefined });
+        }
+    }
+
+    async updateStatusRecord(record: StatusRecord): Promise<ScrobbleActionResult> {
+        const input: ComAtprotoRepoPutRecord.InputSchema = {
+            repo: this.agent.sessionManager.did,
+            collection: "fm.teal.alpha.actor.status",
+            rkey: "self",
+            record
+        };
+        try {
+            const resp = await this.agent.com.atproto.repo.putRecord(input);
+            return {payload: input, response: resp.data};
+        } catch (e) {
+            throw new ScrobbleSubmitError(`Failed to update status record for scrobble`, { cause: e, payload: input, response: 'response' in e ? e.response : undefined });
         }
     }
 
@@ -106,6 +121,19 @@ export const playToRecord = (play: PlayObject): ScrobbleRecord => {
     };
 
     return record;
+}
+
+export const playToStatusRecord = (play: PlayObject, notPlaying: boolean, position?: number): StatusRecord => {
+    const { $type, ...item } = playToRecord(play);
+    return {
+        $type: "fm.teal.alpha.actor.status",
+        time: dayjs().toISOString(),
+        // expiry is 1min ago if paused, (now + duration - position) if position is available, or fallback to (now + 10mins)
+        expiry: notPlaying ? dayjs().subtract(1, 'minute').toISOString()
+            : position !== undefined ? dayjs().add(play.data.duration - position, 'second').toISOString()
+            : dayjs().add(10, 'minute').toISOString(),
+        item
+    };
 }
 
 export const listRecordToPlay = (listRecord: ListRecord<ScrobbleRecord>): PlayObject => {

--- a/src/backend/scrobblers/TealfmScrobbler.ts
+++ b/src/backend/scrobblers/TealfmScrobbler.ts
@@ -17,7 +17,6 @@ export default class TealScrobbler extends AbstractScrobbleClient {
 
     requiresAuth = true;
     requiresAuthInteraction = false;
-    clearedStatus = false; // tracks if a user's status has been cleared on their repo
 
     declare config: TealClientConfig;
 
@@ -127,21 +126,25 @@ export default class TealScrobbler extends AbstractScrobbleClient {
         const notPlaying = [CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused].includes(data.status.calculated as ReportedPlayerStatus);
         try {
             await this.client.updateStatusRecord(playToStatusRecord(data.play, notPlaying, data.position));
-            this.clearedStatus = notPlaying;
         } catch (e) {
             throw e;
         }
     }
 
+    wasLastStatusCleared = () => {
+    return this.nowPlayingLastPlay !== undefined 
+      && [CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused].includes(this.nowPlayingLastPlay.status.calculated as ReportedPlayerStatus)
+    }
+
     shouldUpdatePlayingNowPlatformSpecific = async (data: SourcePlayerObj): Promise<[boolean, string?, LogLevel?]> => {
-        if ([CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused].includes(data.status.calculated as ReportedPlayerStatus) && !this.clearedStatus
+        if ([CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused].includes(data.status.calculated as ReportedPlayerStatus) && !this.wasLastStatusCleared()
             || [CALCULATED_PLAYER_STATUSES.playing].includes(data.status.calculated as ReportedPlayerStatus)
             || (data.nowPlayingMode && !CALCULATED_PLAYER_STATUSES.stopped)) {
             return [true];
         } else {
             if(!data.nowPlayingMode && ![CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused, CALCULATED_PLAYER_STATUSES.playing].includes(data.status.calculated as ReportedPlayerStatus)) {
                 return [false,`player is not in state: stopped | paused | playing => Found '${data.status.calculated }'`];
-            } else if (this.clearedStatus) {
+            } else if (this.wasLastStatusCleared()) {
                 return [false, 'teal.fm status has already been set to expired'];
             } else if (data.nowPlayingMode && CALCULATED_PLAYER_STATUSES.stopped) {
                 this.npLogger.trace(`Will not update because now playing player is stopped => Found ${data.status.calculated}`);

--- a/src/backend/scrobblers/TealfmScrobbler.ts
+++ b/src/backend/scrobblers/TealfmScrobbler.ts
@@ -1,9 +1,9 @@
-import { Logger } from "@foxxmd/logging";
+import { Logger, LogLevel } from "@foxxmd/logging";
 import EventEmitter from "events";
-import { PlayObject } from "../../core/Atomic.js";
+import { PlayObject, SourcePlayerObj } from "../../core/Atomic.js";
 import { buildTrackString, capitalize } from "../../core/StringUtils.js";
 import { isNodeNetworkException } from "../common/errors/NodeErrors.js";
-import { FormatPlayObjectOptions } from "../common/infrastructure/Atomic.js";
+import { FormatPlayObjectOptions, CALCULATED_PLAYER_STATUSES, ReportedPlayerStatus } from "../common/infrastructure/Atomic.js";
 import { playToListenPayload } from '../common/vendor/listenbrainz/lzUtils.js';
 import { Notifiers } from "../notifier/Notifiers.js";
 
@@ -11,12 +11,13 @@ import AbstractScrobbleClient from "./AbstractScrobbleClient.js";
 import { TealClientConfig } from "../common/infrastructure/config/client/tealfm.js";
 import { BlueSkyAppApiClient } from "../common/vendor/bluesky/BlueSkyAppApiClient.js";
 import { BlueSkyOauthApiClient } from "../common/vendor/bluesky/BlueSkyOauthApiClient.js";
-import { AbstractBlueSkyApiClient, listRecordToPlay, playToRecord, recordToPlay } from "../common/vendor/bluesky/AbstractBlueSkyApiClient.js";
+import { AbstractBlueSkyApiClient, listRecordToPlay, playToRecord, playToStatusRecord, recordToPlay } from "../common/vendor/bluesky/AbstractBlueSkyApiClient.js";
 
 export default class TealScrobbler extends AbstractScrobbleClient {
 
     requiresAuth = true;
     requiresAuthInteraction = false;
+    clearedStatus = false; // tracks if a user's status has been cleared on their repo
 
     declare config: TealClientConfig;
 
@@ -26,7 +27,7 @@ export default class TealScrobbler extends AbstractScrobbleClient {
         super('tealfm', name, config, notifier, emitter, logger);
         this.MAX_INITIAL_SCROBBLES_FETCH = 20;
         this.scrobbleDelay = 1500;
-        this.supportsNowPlaying = false;
+        this.supportsNowPlaying = true;
         if(config.data.appPassword !== undefined) {
             this.client = new BlueSkyAppApiClient(name, config.data, {...options, logger});
             this.requiresAuthInteraction = false;
@@ -119,6 +120,35 @@ export default class TealScrobbler extends AbstractScrobbleClient {
         } catch (e) {
             await this.notifier.notify({title: `Client - ${capitalize(this.type)} - ${this.name} - Scrobble Error`, message: `Failed to scrobble => ${buildTrackString(playObj)} | Error: ${e.message}`, priority: 'error'});
             throw e;
+        }
+    }
+
+    doPlayingNow = async (data: SourcePlayerObj) => {
+        const notPlaying = [CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused].includes(data.status.calculated as ReportedPlayerStatus);
+        try {
+            await this.client.updateStatusRecord(playToStatusRecord(data.play, notPlaying, data.position));
+            this.clearedStatus = notPlaying;
+        } catch (e) {
+            throw e;
+        }
+    }
+
+    shouldUpdatePlayingNowPlatformSpecific = async (data: SourcePlayerObj): Promise<[boolean, string?, LogLevel?]> => {
+        if ([CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused].includes(data.status.calculated as ReportedPlayerStatus) && !this.clearedStatus
+            || [CALCULATED_PLAYER_STATUSES.playing].includes(data.status.calculated as ReportedPlayerStatus)
+            || (data.nowPlayingMode && !CALCULATED_PLAYER_STATUSES.stopped)) {
+            return [true];
+        } else {
+            if(!data.nowPlayingMode && ![CALCULATED_PLAYER_STATUSES.stopped, CALCULATED_PLAYER_STATUSES.paused, CALCULATED_PLAYER_STATUSES.playing].includes(data.status.calculated as ReportedPlayerStatus)) {
+                return [false,`player is not in state: stopped | paused | playing => Found '${data.status.calculated }'`];
+            } else if (this.clearedStatus) {
+                return [false, 'teal.fm status has already been set to expired'];
+            } else if (data.nowPlayingMode && CALCULATED_PLAYER_STATUSES.stopped) {
+                this.npLogger.trace(`Will not update because now playing player is stopped => Found ${data.status.calculated}`);
+                return [false,`playing player is stopped => Found ${data.status.calculated}` ]
+            } else {
+                return [false, 'player is in an unexpected state for teal.fm usage']
+            }
         }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

`fm.teal.alpha.actor.status` now gets updated at the `self` rkey to reflect Multi-Scrobbler's now playing status. Most logic was pulled from the existing teal client code and the discord scrobbler.

Functionality should match (or go beyond) what Piper does in my experience. When `doPlayingNow` is called, the `fm.teal.alpha.actor.status` will be updated in a similar fashion to `fm.teal.alpha.feed.play`.

A new `StatusRecord` interface for this is created:
- `$type` is `fm.teal.alpha.actor.status`
- `item` is just `ScrobbleRecord`, but without inheriting its `$type`
- `time` is now, the time when the update is sent (different from `playedTime`)
- `expiry` is (now + duration - position). 
  - If duration isn't available, we fallback to (now + 10mins). 
  - If playback is paused or stopped, the expiry will be updated to (now - 1min), to indicate it is not currently playing. 

I've tested a bit with Plex as a source and it all seems to work well. As with most of teal.fm, there isn't anything official that uses this record yet, but [my website](https://hiijax.net)'s sidebar uses it, so it became something I wanted Multi-Scrobbler to do.

P.S. bear with me this is my first real PR in the FOSS community :) 

## Issue number and link, if applicable

