### PR TITLE
fix(mpd): Assign empty array if artists not defined

### DIFF
--- a/src/backend/sources/MPDSource.ts
+++ b/src/backend/sources/MPDSource.ts
@@ -150,8 +150,8 @@ export class MPDSource extends MemoryPositionalSource {
 
         let trackName: string,
         album: string,
-        artists: string[] = [],
-        albumArtists: string[] = [],
+        artists: string[] | undefined = [],
+        albumArtists: string[] | undefined = [],
         duration: number,
         position: number,
         brainz: BrainzMeta = {};
@@ -257,8 +257,8 @@ export class MPDSource extends MemoryPositionalSource {
 
         const play: PlayObjectLifecycleless = {
             data: {
-                artists: artistNamesToCredits(artists),
-                albumArtists: artistNamesToCredits(albumArtists),
+                artists: artists !== undefined ? artistNamesToCredits(artists) : [],
+                albumArtists: albumArtists !== undefined ? artistNamesToCredits(albumArtists) : [],
                 album,
                 track: trackName,
                 duration


### PR DESCRIPTION
#621

## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

If mpd entry type is not a song then albumArtist, or artist, may be undefined. Default assignment to an empty array if the respective variable is undefined.

## Issue number and link, if applicable

#621