### PR TITLE
fix: Guard against tracks/track in mb recording medium

### DIFF
--- a/patches/musicbrainz-api+0.27.1.patch
+++ b/patches/musicbrainz-api+0.27.1.patch
@@ -115,3 +115,17 @@ index 72fb15d..f6bdfe5 100644
          });
          return response.json();
      }
+diff --git a/node_modules/musicbrainz-api/lib/musicbrainz.types.d.ts b/node_modules/musicbrainz-api/lib/musicbrainz.types.d.ts
+index 1ebc7b2..e004b9b 100644
+--- a/node_modules/musicbrainz-api/lib/musicbrainz.types.d.ts
++++ b/node_modules/musicbrainz-api/lib/musicbrainz.types.d.ts
+@@ -156,7 +156,8 @@ export interface IMedium {
+     title: string;
+     format?: string;
+     'format-id': string;
+-    tracks: ITrack[];
++    tracks?: ITrack[];
++    track?: ITrack[]
+     'track-count': number;
+     'track-offset': number;
+     position: number;

--- a/src/backend/common/transforms/MusicbrainzTransformer.ts
+++ b/src/backend/common/transforms/MusicbrainzTransformer.ts
@@ -863,7 +863,15 @@ export const filterByExplicitTrackMbid = (list: IRecordingMatch[], play: PlayObj
             break;
         }
         for (const rel of rec.releases) {
-            if (rel.media.some(x => x.tracks.some(y => y.id === play.data.meta.brainz.track))) {
+            if (rel.media.some(x => {
+                if(x.tracks !== undefined) {
+                    return x.tracks.some(y => y.id === play.data.meta.brainz.track);
+                }
+                if(x.track !== undefined) {
+                    return x.track.some(y => y.id === play.data.meta.brainz.track);
+                }
+                return false;
+            })) {
                 releaseMatchId = rel.id;
                 recMatch = rec;
                 break;

--- a/src/backend/common/vendor/musicbrainz/MusicbrainzApiClient.ts
+++ b/src/backend/common/vendor/musicbrainz/MusicbrainzApiClient.ts
@@ -201,7 +201,7 @@ export class MusicbrainzApiClient extends AbstractApiClient {
                 throw new SimpleError('Timeout occurred while waiting for Musicbrainz API rate limit');
             }
             if(`error` in res) {
-                throw Error(res.error);
+                throw new Error(res.error);
             }
             return res as T;
         } catch (e) {

--- a/src/backend/tests/musicbrainz/musicbrainz.test.ts
+++ b/src/backend/tests/musicbrainz/musicbrainz.test.ts
@@ -16,6 +16,7 @@ import { generatePlay, withBrainz } from '../../../core/tests/utils/PlayTestUtil
 import { intersect, missingMbidTypes } from '../../utils.ts';
 import { CoverArtApiClient, type CoverArtApiConfig } from '../../common/vendor/musicbrainz/CoverArtApiClient.ts';
 import { artistNamesToCredits, artistNameToCredit } from '../../../core/StringUtils.ts';
+import dayjs from 'dayjs';
 
 chai.use(asPromised);
 
@@ -422,6 +423,76 @@ describe('Musicbrainz API', function () {
                     "releaseGroupPrimaryTypePriority": ["album", "single", "ep"],
                     "releaseCountryPriority": ["XW"],
                 }), "All search prerequisites failed")
+        });
+
+        it('does not fail on media tracks', async function () {
+            this.timeout(35000);
+
+            await mbTransformer.initialize();
+
+            const play: PlayObject = {
+                "data": {
+                    "artists": [
+                        {
+                            "name": "Au5",
+                            "mbid": "3569c2ed-2315-40d9-b041-3c48dae1be43"
+                        }
+                    ],
+                    "albumArtists": [],
+                    "album": "Inverse",
+                    "track": "Scission",
+                    "duration": 214.125,
+                    "meta": {
+                        "brainz": {
+                            "track": "c63b7e96-928c-48dd-b558-a181cb245cb6",
+                            "album": "cbc89dff-3555-498c-bb1e-2ff983b13e59",
+                            "artist": [
+                                "3569c2ed-2315-40d9-b041-3c48dae1be43"
+                            ],
+                            "albumArtist": [
+                                "3569c2ed-2315-40d9-b041-3c48dae1be43"
+                            ]
+                        }
+                    },
+                    "playDate": dayjs(),
+                    "listenedFor": 209.601,
+                    "listenRanges": [],
+                    "repeat": false
+                },
+                "meta": {
+                    "seenAt": dayjs(),
+                    "trackId": "plex://track/6a5ee492569fa956516b9b1a",
+                    "mediaType": "track",
+                    "source": "Plex",
+                    "library": "Music",
+                    "deviceId": "sonos-0116-Plex for Sonos",
+                    "sessionId": "106",
+                    "trackProgressPosition": 214.125,
+                    "art": {
+                        "track": "/api/source/art?name=PlexBox&type=plex&data=84389"
+                    }
+                },
+            };
+
+            try {
+                const res = await mbTransformer.getTransformerData(play, {
+                    type: "musicbrainz",
+                    searchWhenMissing: DEFAULT_MISSING_TYPES,
+                    searchOrder: ["isrc", "mbidrecording", "basicorids", "basic"],
+                });
+
+                expect(res.recordings).to.exist;
+                expect(res.recordings).to.not.be.empty;
+                const chosenPlay = await mbTransformer.handlePostFetch(play, res, {
+                    type: "musicbrainz",
+                    searchWhenMissing: DEFAULT_MISSING_TYPES,
+                    searchOrder: ["isrc", "mbidrecording", "basicorids", "basic"],
+                });
+                expect(chosenPlay).to.exist;
+            } catch (e) {
+                throw e;
+            }
+
         });
 
     });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

Fixes trying to access undefined `tracks` on mb recording `medium`. It looks like if a `recording` has a release-medium with only one track than sometimes mb will return `track: []` instead of `tracks: []`. This only seems to occur when searching, though. Regular lookups have the correct `tracks: []` shape.

## Issue number and link, if applicable

Fixes #649

Borewit/musicbrainz-api#1188