### PR TITLE
Ingress sot

### DIFF
--- a/src/backend/scrobblers/AbstractScrobbleClient.ts
+++ b/src/backend/scrobblers/AbstractScrobbleClient.ts
@@ -15,7 +15,8 @@ import {
     type PlayOriginal,
     type PlayLifecycle,
     type SourcePlayerJson,
-    QUEUE_STATUS_COMPLETED
+    QUEUE_STATUS_COMPLETED,
+    SOURCE_SOT
 } from "../../core/Atomic.ts";
 import { artistNamesToCredits, buildTrackString, capitalize, truncateStringToLength } from "../../core/StringUtils.ts";
 import AbstractComponent from "../common/AbstractComponent.ts";
@@ -73,10 +74,17 @@ import assert from "node:assert";
 import { COMPONENT_STATE, type ComponentClientApiJson, type PlayApiCommonDetailed } from "../../core/Api.ts";
 import type {ComponentState} from "react";
 
-type PlatformMappedPlays = Map<string, {player: SourcePlayerObj, source: SourceIdentifier}>;
+type SourceMappedPlayer = {player: SourcePlayerObj, source: SourceIdentifier};
+type PlatformMappedPlays = Map<string, SourceMappedPlayer>;
 type NowPlayingQueue = Map<string, PlatformMappedPlays>;
 
 const platformTruncate = truncateStringToLength(10);
+
+const bufferNPUpdateReasonFragments: string[] = [
+    'previous update play data does not match current',
+    'player in valid update state',
+    'less than min threshold'
+];
 
 export default abstract class AbstractScrobbleClient extends AbstractComponent implements Authenticatable {
 
@@ -116,7 +124,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
     nowPlayingIsRealtime: boolean = false;
     nowPlayingInit: boolean = false;
     nowPlayingEnabled: boolean;
-    nowPlayingFilter: (queue: NowPlayingQueue) => SourcePlayerObj | undefined;
+    nowPlayingFilter: (queue: NowPlayingQueue) => SourceMappedPlayer | undefined;
     nowPlayingMinThreshold: NowPlayingUpdateThreshold = (_) => 10;
     nowPlayingMaxThreshold: NowPlayingUpdateThreshold = (_) => 30;
     nowPlayingLastUpdated?: Dayjs;
@@ -542,7 +550,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                 }
             }
 
-            this.nowPlayingFilter = (queue: NowPlayingQueue): SourcePlayerObj => {
+            this.nowPlayingFilter = (queue: NowPlayingQueue): SourceMappedPlayer => {
                 if (queue.size === 0) {
                     return undefined;
                 }
@@ -555,7 +563,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                 // if only one player then return it
                 const plays = Array.from(platformPlays);
                 if (plays.length === 1) {
-                    return plays[0][1].player;
+                    return plays[0][1];
                 }
                 // else we need to sort players to determine which to report
 
@@ -568,7 +576,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                         if (platform === this.nowPlayingLastPlay.platformId
                             // only keep using sticky platform if it hasn't gone stale/orphaned
                             && (!(data.player.status?.stale ?? false) && !(data.player.status?.orphaned ?? false))) {
-                            return data.player;
+                            return data;
                         }
                     }
                 }
@@ -582,7 +590,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
 
                 // otherwise sort platform alphabetically and take first
                 preferredPlays.sort((a, b) => a[0].localeCompare(b[0]));
-                return preferredPlays[0][1].player;
+                return preferredPlays[0][1];
             }
         }
     }
@@ -1638,14 +1646,14 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                 return;
             }
             // eslint-disable-next-line prefer-const
-            let [shouldUpdate, npUpdateTopReason] = this.shouldUpdatePlayingNow(sourcePlayerData);
+            let [shouldUpdate, npUpdateTopReason] = this.shouldUpdatePlayingNow(sourcePlayerData.player);
             let clientReason: string | undefined;
             if(!shouldUpdate) {
                 this.npLogger.trace(`Not updating, ${npUpdateTopReason}`);
             }
 
             if(shouldUpdate) {
-                const [clientUpdate, clientUpdateReason, level] = await this.shouldUpdatePlayingNowPlatformSpecific(sourcePlayerData);
+                const [clientUpdate, clientUpdateReason, level] = await this.shouldUpdatePlayingNowPlatformSpecific(sourcePlayerData.player);
                 clientReason = clientUpdateReason;
                 shouldUpdate = clientUpdate;
                 if(!clientUpdate) {
@@ -1653,29 +1661,45 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                 }
             }
 
+            const cleanNowPlayingQueue = new Map();
+
             // finally, do the update
             if(shouldUpdate) {
                 this.npLogger.verbose(`Updating because ${npUpdateTopReason}${clientReason !== undefined ? ` --AND-- ${clientReason}` : ''}`);
-                const isClearing = this.nowPlayingIsRealtime && shouldClearNPStatus(sourcePlayerData);
+                const isClearing = this.nowPlayingIsRealtime && shouldClearNPStatus(sourcePlayerData.player);
                 try {
-                    await this.doPlayingNow(sourcePlayerData);
+                    await this.doPlayingNow(sourcePlayerData.player);
                     this.npLogger.trace(`Now Playing updated.`);
                     this.setStatus('Now Playing updated');
                     if(!isClearing) {
-                        this.nowPlayingExpirationDate = dayjs().add(nowPlayingExpirationDuration(sourcePlayerData));
+                        this.nowPlayingExpirationDate = dayjs().add(nowPlayingExpirationDuration(sourcePlayerData.player));
                         this.emitEvent('playerUpdate', {...sourcePlayerData, expiration: this.nowPlayingExpirationDate});
                     } else {
                         this.nowPlayingExpirationDate = undefined;
-                        this.emitEvent('playerDelete', {platformId: sourcePlayerData.platformId});
+                        this.emitEvent('playerDelete', {platformId: sourcePlayerData.player.platformId});
                     }
                     this.emitEvent('nowPlayingUpdated', sourcePlayerData);
                 } catch (e) {
                     this.npLogger.warn(new Error('Error occurred while trying to update upstream Client, will ignore', {cause: e}));
                 }
-                this.nowPlayingLastPlay = sourcePlayerData;
+                this.nowPlayingLastPlay = sourcePlayerData.player;
                 this.nowPlayingLastUpdated = dayjs();
+            } else {
+                if(sourcePlayerData.player.play?.meta?.sourceSOT === SOURCE_SOT.INGRESS && bufferNPUpdateReasonFragments.every((x) => npUpdateTopReason.includes(x))) {
+                    // update is for an ingress Source and is valid
+                    // but time since last update was less than client threshold interval
+                    // 
+                    // Ingress Sources may not send any additional updates to MS until a scrobble event
+                    // so, otherwise, NP would never be updated until that happens
+                    //
+                    // to prevent that we want client NP to update with this *valid* update after min threshold is met
+                    // so we will re-queue the update so that it gets used in a subsequent NP processing run
+                    this.npLogger.debug('Re-queuing valid NP update from ingress Source that did not meet min threshold');
+                    const sourceId = `${sourcePlayerData.source.name}-${sourcePlayerData.source.type}`;
+                    cleanNowPlayingQueue.set(sourceId, this.nowPlayingQueue.get(sourceId));
+                }
             }
-            this.nowPlayingQueue = new Map();
+            this.nowPlayingQueue = cleanNowPlayingQueue;
         }
     }
 

--- a/src/backend/scrobblers/AbstractScrobbleClient.ts
+++ b/src/backend/scrobblers/AbstractScrobbleClient.ts
@@ -1673,7 +1673,7 @@ export default abstract class AbstractScrobbleClient extends AbstractComponent i
                     this.setStatus('Now Playing updated');
                     if(!isClearing) {
                         this.nowPlayingExpirationDate = dayjs().add(nowPlayingExpirationDuration(sourcePlayerData.player));
-                        this.emitEvent('playerUpdate', {...sourcePlayerData, expiration: this.nowPlayingExpirationDate});
+                        this.emitEvent('playerUpdate', {...sourcePlayerData.player, expiration: this.nowPlayingExpirationDate});
                     } else {
                         this.nowPlayingExpirationDate = undefined;
                         this.emitEvent('playerDelete', {platformId: sourcePlayerData.player.platformId});

--- a/src/backend/sources/EndpointLastfmSource.ts
+++ b/src/backend/sources/EndpointLastfmSource.ts
@@ -29,7 +29,7 @@ export class EndpointLastfmSource extends MemorySource {
     constructor(name: any, config: LastFMEndpointSourceConfig, internal: InternalConfig, emitter: EventEmitter) {
         super('endpointlfm', name, config, internal, emitter);
         this.multiPlatform = false;
-        this.playerSourceOfTruth = SOURCE_SOT.HISTORY;
+        this.playerSourceOfTruth = SOURCE_SOT.INGRESS;
 
         const {
             data = {},
@@ -95,7 +95,7 @@ export class EndpointLastfmSource extends MemorySource {
 
 export const playStateFromRequest = (obj: Record<LastFMPayloadkey, unknown>): PlayerStateData[] => ingressPayloads(obj).map(x => {
         const play = scrobblePayloadToPlay(x);
-        play.meta.sourceSOT = SOURCE_SOT.HISTORY;
+        play.meta.sourceSOT = SOURCE_SOT.INGRESS;
         return {
             platformId: [play.meta.deviceId, NO_USER],
             play,

--- a/src/backend/sources/EndpointListenbrainzSource.ts
+++ b/src/backend/sources/EndpointListenbrainzSource.ts
@@ -32,7 +32,7 @@ export class EndpointListenbrainzSource extends MemorySource {
     constructor(name: any, config: ListenbrainzEndpointSourceConfig, internal: InternalConfig, emitter: EventEmitter) {
         super('endpointlz', name, config, internal, emitter);
         this.multiPlatform = false;
-        this.playerSourceOfTruth = SOURCE_SOT.HISTORY;
+        this.playerSourceOfTruth = SOURCE_SOT.INGRESS;
 
         const {
             data = {},
@@ -127,7 +127,7 @@ export const playStateFromRequest = (obj: SubmitPayload): PlayerStateData[] => {
 
     const playStates: PlayerStateData[] = payload.map((x) => {
         const play = listenPayloadToPlay(x, listen_type === 'playing_now');
-        play.meta.sourceSOT = SOURCE_SOT.HISTORY;
+        play.meta.sourceSOT = SOURCE_SOT.INGRESS;
         return {
             platformId: [play.meta.deviceId, NO_USER],
             play,

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -68,21 +68,7 @@ export default class MemorySource extends AbstractSource {
                 .withConcurrency(1)
                 .for(this.players.keys())
                 .process(async (key) => {
-
                     await this.cleanupPlayer(key);
-                    if(this.playerSourceOfTruth === SOURCE_SOT.INGRESS) {
-                        const player = this.players.get(key);
-                        if(![CALCULATED_PLAYER_STATUSES.stale, CALCULATED_PLAYER_STATUSES.orphaned].includes(player.calculatedStatus)) {
-                            // if player isn't stale and this is an ingress source then we want to keep pushing playerUpdates
-                            // so that any downstream Clients can update Now Playing in a timely manner
-                            this.emitEvent('playerUpdate', {
-                                ...player.getApiState(),
-                                options: {
-                                    scrobbleTo: this.clients
-                                }
-                            });
-                        }
-                    }
                 });
         })));
     }

--- a/src/backend/sources/MemorySource.ts
+++ b/src/backend/sources/MemorySource.ts
@@ -60,7 +60,7 @@ export default class MemorySource extends AbstractSource {
 
         // player cleanup on *schedule* is needed when the Source is non-polling (ingress)
         // because if the source stops sending updates then processRecentPlays() was never called so we never remove old players
-        this.scheduler.addSimpleIntervalJob(new SimpleIntervalJob({ seconds: 15 }, new AsyncTask('Player Cleanup', (): Promise<any> => {
+        this.scheduler.addSimpleIntervalJob(new SimpleIntervalJob({ seconds: 10 }, new AsyncTask('Player Cleanup', (): Promise<any> => {
             if (this.canPoll) {
                 return Promise.resolve();
             }
@@ -70,6 +70,19 @@ export default class MemorySource extends AbstractSource {
                 .process(async (key) => {
 
                     await this.cleanupPlayer(key);
+                    if(this.playerSourceOfTruth === SOURCE_SOT.INGRESS) {
+                        const player = this.players.get(key);
+                        if(![CALCULATED_PLAYER_STATUSES.stale, CALCULATED_PLAYER_STATUSES.orphaned].includes(player.calculatedStatus)) {
+                            // if player isn't stale and this is an ingress source then we want to keep pushing playerUpdates
+                            // so that any downstream Clients can update Now Playing in a timely manner
+                            this.emitEvent('playerUpdate', {
+                                ...player.getApiState(),
+                                options: {
+                                    scrobbleTo: this.clients
+                                }
+                            });
+                        }
+                    }
                 });
         })));
     }

--- a/src/backend/sources/WebScrobblerSource.ts
+++ b/src/backend/sources/WebScrobblerSource.ts
@@ -34,7 +34,7 @@ export class WebScrobblerSource extends MemorySource {
     constructor(name: any, config: WebScrobblerSourceConfig, internal: InternalConfig, emitter: EventEmitter) {
         super('webscrobbler', name, config, internal, emitter);
         this.multiPlatform = true;
-        this.playerSourceOfTruth = SOURCE_SOT.HISTORY;
+        this.playerSourceOfTruth = SOURCE_SOT.INGRESS;
         this.logger.info(`Note: The player for this source is an analogue for the 'Now Playing' status exposed by ${this.type} which is NOT used for scrobbling. Instead, the 'recently played' or 'history' information provided by this source is used for scrobbles.`)
 
         const {
@@ -88,7 +88,7 @@ export class WebScrobblerSource extends MemorySource {
         } = obj;
 
         const play = WebScrobblerSource.formatPlayObj(obj.data.song, {nowPlaying: eventName !== 'scrobble'});
-        play.meta.sourceSOT = SOURCE_SOT.HISTORY;
+        play.meta.sourceSOT = SOURCE_SOT.INGRESS;
         return {
             platformId: [play.meta.deviceId, NO_USER],
             play,

--- a/src/backend/tests/scrobbler/scrobblers.test.ts
+++ b/src/backend/tests/scrobbler/scrobblers.test.ts
@@ -865,7 +865,7 @@ describe('Now Playing', function() {
 
                 const toReport = npScrobbler.nowPlayingFilter(npScrobbler.nowPlayingQueue);
 
-                expect(toReport.play.meta.deviceId).eq(genGroupIdStr(firstPlatform));
+                expect(toReport.player.play.meta.deviceId).eq(genGroupIdStr(firstPlatform));
 
             });
 
@@ -886,7 +886,7 @@ describe('Now Playing', function() {
 
                 const toReport = npScrobbler.nowPlayingFilter(npScrobbler.nowPlayingQueue);
 
-                expect(toReport.play.meta.deviceId).eq(genGroupIdStr(firstPlatform));
+                expect(toReport.player.play.meta.deviceId).eq(genGroupIdStr(firstPlatform));
 
             });
 
@@ -910,7 +910,7 @@ describe('Now Playing', function() {
 
                 const toReport = npScrobbler.nowPlayingFilter(npScrobbler.nowPlayingQueue);
 
-                expect(toReport.play.meta.deviceId).eq(genGroupIdStr(secondPlatform));
+                expect(toReport.player.play.meta.deviceId).eq(genGroupIdStr(secondPlatform));
 
             });
 
@@ -927,7 +927,7 @@ describe('Now Playing', function() {
 
                 const toReport = npScrobbler.nowPlayingFilter(npScrobbler.nowPlayingQueue);
 
-                expect(toReport.play.meta.deviceId).eq(a.play.meta.deviceId);
+                expect(toReport.player.play.meta.deviceId).eq(a.play.meta.deviceId);
 
             });
 
@@ -944,7 +944,7 @@ describe('Now Playing', function() {
 
                 const toReport = npScrobbler.nowPlayingFilter(npScrobbler.nowPlayingQueue);
 
-                expect(toReport.play.meta.deviceId).eq(b.play.meta.deviceId);
+                expect(toReport.player.play.meta.deviceId).eq(b.play.meta.deviceId);
 
             });
 

--- a/src/backend/utils/PlayComparisonUtils.ts
+++ b/src/backend/utils/PlayComparisonUtils.ts
@@ -1,5 +1,5 @@
 import { getListDiff, type ListDiff } from "@donedeal0/superdiff";
-import { type PlayMatchResult, type PlayObject, type PlayObjectMinimal, SOURCE_SOT, TA_DURING, TA_EXACT, TA_FUZZY, type TemporalAccuracy, type TrackStringOptions } from "../../core/Atomic.ts";
+import { type PlayMatchResult, type PlayObject, type PlayObjectMinimal, SOURCE_SOT, type SOURCE_SOT_TYPES, TA_DURING, TA_EXACT, TA_FUZZY, type TemporalAccuracy, type TrackStringOptions } from "../../core/Atomic.ts";
 import { buildTrackString, capitalize, truncateStringToLength } from "../../core/StringUtils.ts";
 import { comparingMultipleArtists, playObjDataMatch, setIntersection } from "../utils.ts";
 import { comparePlayTemporally, hasAcceptableTemporalAccuracy, temporalAccuracyToString, type TemporalPlayComparisonOptions, temporalPlayComparisonSummary } from "./TimeUtils.ts";
@@ -496,7 +496,7 @@ export const existingScrobble = async (playObjPre: PlayObject, existingScrobbles
             //
             // OR if play was generated from a source that uses History (endpoint sources, lfm or lz history sources)
             // then we can be reasonably sure that our candidate play has an accurate timestamp and wouldn't fuzzy match a previous scrobble
-            const looseTimeAccuracy = playObj.data.repeat || playObj.meta.sourceSOT === SOURCE_SOT.HISTORY ? [TA_DURING] : [TA_FUZZY, TA_DURING];
+            const looseTimeAccuracy = playObj.data.repeat || ([SOURCE_SOT.HISTORY, SOURCE_SOT.INGRESS] as SOURCE_SOT_TYPES[]).includes(playObj.meta.sourceSOT) ? [TA_DURING] : [TA_FUZZY, TA_DURING];
 
             
             existingScrobble = await findAsyncSequential(existingScrobbles, async (xPre) => {

--- a/src/client/components/player/Player.tsx
+++ b/src/client/components/player/Player.tsx
@@ -83,7 +83,7 @@ art = {},
     return (
             <article className={["player", "mb-2"].join(' ')}>
                 <div className="player__wrapper">
-                    {sot === SOURCE_SOT.HISTORY ? <span className="player-tooltip"><Tooltip
+                    {sot !== SOURCE_SOT.PLAYER ? <span className="player-tooltip"><Tooltip
                     classNames={['justify-end', 'mr-4']}
                      message="This player is for DISPLAY ONLY and likely represents a 'Now Playing' status exposed by the Source. For scrobbling Multi Scrobbler uses the 'recently played' or 'history' information provided by this source.">
                         <FontAwesomeIcon width={9} color="black" icon={faQuestion}/>

--- a/src/core/Atomic.ts
+++ b/src/core/Atomic.ts
@@ -469,12 +469,13 @@ export interface TemporalPlayComparison {
     } | { type: 'none' }
 }
 
-export type SOURCE_SOT_TYPES = 'player' | 'history';
+export type SOURCE_SOT_TYPES = 'player' | 'history' | 'ingress';
 export const SOURCE_SOT = {
-    PLAYER : 'player' as SOURCE_SOT_TYPES,
-    HISTORY: 'history' as SOURCE_SOT_TYPES
-}
-export const sourceSotTypes: SOURCE_SOT_TYPES[] = ['player','history'];
+    PLAYER : 'player',
+    HISTORY: 'history',
+    INGRESS: 'ingress'
+} as const satisfies Record<string, SOURCE_SOT_TYPES>
+export const sourceSotTypes: SOURCE_SOT_TYPES[] = ['player','history','ingress'];
 
 export interface URLData {
     url: URL


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

* Add `ingress` player source-of-truth type to differentiate webscrobbler/lz/lfm endpoint sources from `history` sources
* Basically the same behavior *for now* except ingress players get `playerUpdate` events emitted on non-stale player cleanup to make sure downstream Now Playing changes are propogated without needing another request from the application using the endpoint #659

## Issue number and link, if applicable

#659