### PR TITLE
fix(AppleMusicSource): include library-songs in recent tracks

### DIFF
--- a/src/backend/sources/AppleMusicSource.ts
+++ b/src/backend/sources/AppleMusicSource.ts
@@ -159,7 +159,7 @@ export default class AppleMusicSource extends AbstractSource {
 
     private getTracks = async (limit: number): Promise<PlayObject[]> => {
         const clampedLimit = Math.max(1, Math.min(this.UPSTREAM_TRACK_LIMIT, Math.round(limit)));
-        const result = await this.musicKit.me.history.getRecentlyPlayedTracks({ limit: clampedLimit as MeHistoryRecentlyPlayedTracksProps["limit"], types: ["songs"] });
+        const result = await this.musicKit.me.history.getRecentlyPlayedTracks({ limit: clampedLimit as MeHistoryRecentlyPlayedTracksProps["limit"], types: ["songs", "library-songs"] });
         if (result.error) {
             throw new Error(result.error);
         }


### PR DESCRIPTION
Updated the Apple Music recently played tracks query to include 'library-songs' types in addition to 'songs', ensuring a more comprehensive history retrieval.

## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

Apple Music treats streamed songs and library songs as seperate types of songs. Songs in playlist may become library songs under certain conditions.

## Issue number and link, if applicable

\-