### PR TITLE
fix(docsite): path.join doesn't really handle http links

### DIFF
--- a/docsite/docusaurus.config.ts
+++ b/docsite/docusaurus.config.ts
@@ -87,7 +87,7 @@ const config: Config = {
               permalink: string;
               locale: string;
             }) => {
-              return `${path.join('https://github.com/FoxxMD/multi-scrobbler/blob/master/docsite', params.versionDocsDirPath, params.docPath)}?plain=1`;
+              return `https://github.com/FoxxMD/multi-scrobbler/blob/master${path.join('/docsite', params.versionDocsDirPath, params.docPath)}?plain=1`;
             }
         },
         // blog: {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

I'll kinda admit i didn't really test it by running build locally, just editing via web app

```
> require('path').join("https://github.com/foo/bar", "/baz")
'https:/github.com/foo/bar/baz'
```

so this change just appends the new stuff to the end of the static string, so it doesn't mess with the ://

## Issue number and link, if applicable

https://docs.multi-scrobbler.app/configuration/?configType=env
edit-this-page goes to https://docs.multi-scrobbler.app/github.com/FoxxMD/multi-scrobbler/blob/master/docsite/docs/configuration/configuration.mdx?plain=1