### PR TITLE
confirm before removing all failed scrobbles

### DIFF
--- a/src/client/deadLetter/DeadPage.tsx
+++ b/src/client/deadLetter/DeadPage.tsx
@@ -54,7 +54,12 @@ const dead = (props: PropsFromRedux) => {
 
     const retryDead = useCallback((id: string) => retryDeadFetch({name: searchParams.get('name'), type: searchParams.get('type'), id}), [retryDeadFetch, searchParams]);
     const removeDead = useCallback((id: string) => removeDeadFetch({name: searchParams.get('name'), type: searchParams.get('type'), id}), [removeDeadFetch, searchParams]);
-    const removeAllDead = useCallback(() => removeAllDeadFetch({name: searchParams.get('name'), type: searchParams.get('type')}), [removeAllDeadFetch, searchParams]);
+    // this deletes everything, no undo, so double check with the user first
+    const removeAllDead = useCallback(() => {
+        if (window.confirm('Remove all failed scrobbles? This cannot be undone.')) {
+            removeAllDeadFetch({name: searchParams.get('name'), type: searchParams.get('type')});
+        }
+    }, [removeAllDeadFetch, searchParams]);
     const retryAllDead = useCallback(() => retryAllDeadFetch({name: searchParams.get('name'), type: searchParams.get('type')}), [retryAllDeadFetch, searchParams]);
 
     return (


### PR DESCRIPTION
Added confirmation dialog before removing all failed scrobbles.

## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](./blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

so "Remove All" on the Failed Scrobbles page apparently just deletes everything instantly, no confirm or anything. one misclick and it's all gone, no undo. fixed it but still kept it simple, just a window.confirm() before it actually fires.

## Issue number and link, if applicable

Fixes #491