### PR TITLE
Rate limiter queue

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,6 +3,7 @@
   "extension": "ts",
   "spec": "./src/backend/tests/**/*.test.ts",
   "file": [
+    "./src/backend/tests/utils/mswGlobalServer.ts",
     "./src/backend/tests/setup.ts"
   ],
   "exit": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "patch-package": "^8.0.1",
         "prom-client": "^15.1.3",
         "qs": "^6.15.2",
+        "rate-limiter-flexible": "^11.2.0",
         "react-use-timeout": "^1.0.0",
         "round-robin-js": "^3.0.10",
         "serialize-error": "^13.0.1",
@@ -17794,6 +17795,12 @@
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-11.2.0.tgz",
+      "integrity": "sha512-L0eIK+BmFMi6NcvmtEg7RSswOFKi9MMD5RhBIypFfOve+G6Jl1Xbb8qEHgK3uRzNtkOFYF0L9f7P4rSf2PnUVw==",
+      "license": "ISC"
     },
     "node_modules/raw-body": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "patch-package": "^8.0.1",
     "prom-client": "^15.1.3",
     "qs": "^6.15.2",
+    "rate-limiter-flexible": "^11.2.0",
     "react-use-timeout": "^1.0.0",
     "round-robin-js": "^3.0.10",
     "serialize-error": "^13.0.1",

--- a/src/backend/common/errors/MSErrors.ts
+++ b/src/backend/common/errors/MSErrors.ts
@@ -171,6 +171,7 @@ export const mergeSimpleError = (err: Error): Error => {
             // @ts-expect-error this is used by serialize error with out custom errors
             mergedErr.toJSON = () => serializeError(mergedErr);
         }
+        return mergedErr;
     }
     return err;
 }

--- a/src/backend/common/vendor/LastfmApiClient.ts
+++ b/src/backend/common/vendor/LastfmApiClient.ts
@@ -17,7 +17,7 @@ import { LastFMUser, LastFMAuth, LastFMTrack, type LastFMUserGetRecentTracksResp
 import clone from 'clone';
 import type { IncomingMessage } from "http";
 import { baseFormatPlayObj } from "../../utils/PlayTransformUtils.ts";
-import { AuthError, ScrobbleSubmitError, SimpleError } from "../errors/MSErrors.ts";
+import { AuthError, mergeSimpleError, ScrobbleSubmitError, SimpleError } from "../errors/MSErrors.ts";
 import { redactString } from "@foxxmd/redact-string";
 import dns from 'node:dns/promises';
 import xml2js from 'xml2js';
@@ -144,6 +144,7 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
                     const { error, attemptNumber, retriesLeft } = context;
                     const parts: string[] = [];
                     let shouldThrow = false;
+
                     if (error instanceof LastFMResponseError) {
                         const status = error.response.statusCode;
                         parts.push(`HTTP ${status}`);
@@ -154,7 +155,7 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
                             parts.push('Api call failed due unexpected non-json response');
                             if (error.content !== undefined) {
                                 // add some truncated response content
-                                parts.push(`Contents (truncated): ${truncateStringToLength(100, error.content)}`);
+                                parts.push(`Contents (truncated): ${truncateStringToLength(150)(error.content)}`);
                             }
                         } else {
                             const retryError = retryErrors.find(x => error.message.toLocaleLowerCase().includes(x));
@@ -176,12 +177,10 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
                                 parts.push(`Api call failed due to a retryable error: ${retryError}`);
                             }
                         }
-
-                        const reasonError = new SimpleError(parts.join(' | '), {cause: error});
                         if(shouldThrow) {
-                            throw new SimpleError(`Request attempt ${attemptNumber} failed with non-retryable reason`, {cause: reasonError, shortStack: true});
+                            throw new SimpleError(`Request attempt ${attemptNumber} failed with non-retryable reason: ${parts.join(' | ')}`, {cause: error, shortStack: false});
                         }
-                        this.logger.warn(new SimpleError(`Request attempt ${attemptNumber} failed. ${retriesLeft} retries left`, {cause: reasonError, shortStack: true}));
+                        this.logger.warn(new SimpleError(`Request attempt ${attemptNumber} failed. ${retriesLeft} retries left: ${parts.join(' | ')}`, {cause: error, shortStack: true}));
                     } else {
                         let networkError: string;
                         const nError = getNodeNetworkException(error);
@@ -193,15 +192,13 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
                         if(networkError === undefined) {
                             throw new SimpleError(`Request attempt ${attemptNumber} failed with non-retryable reason`, {cause: error, shortStack: true});
                         }
-                        const reasonError = new SimpleError(networkError, {cause: error});
-                        this.logger.warn(new SimpleError(`Request attempt ${attemptNumber} failed. ${retriesLeft} retries left`, {cause: reasonError, shortStack: true}));
+                        this.logger.warn(mergeSimpleError(new SimpleError(`Request attempt ${attemptNumber} failed due to network error: ${networkError}`, {cause: error, shortStack: true})));
                     }
                 }
             });
         } catch (e) {
-            if('cause' in e) {
-                // likely this is a caught error from above meaning its from the api and not an MS code error
-                throw new UpstreamError('API call failed', {cause: e});
+            if(e instanceof SimpleError) {
+                throw e;
             }
             throw new Error('API call failed unexpectedly', {cause: e});
         }
@@ -356,7 +353,7 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
             if(unrecoverable === undefined) {
                 const errorWithMessage = findCauseByFunc(e, (ee) => `response` in ee) as Error & {response: IncomingMessage} | undefined;
                 if(errorWithMessage !== undefined) {
-                    unrecoverable = [401,403].includes(errorWithMessage.response.statusCode);
+                    unrecoverable = [401,403].includes(errorWithMessage.response?.statusCode);
                 }
             }
             throw new AuthError('Testing auth failed', {cause: e, unrecoverable});

--- a/src/backend/common/vendor/LastfmApiClient.ts
+++ b/src/backend/common/vendor/LastfmApiClient.ts
@@ -1,6 +1,6 @@
 import dayjs, { type Dayjs, type ManipulateType } from "dayjs";
 import type {BrainzMeta, PlayObject, PlayObjectMinimal, ScrobbleActionResult, UnixTimestamp, URLData, Writeable} from "../../../core/Atomic.ts";
-import { artistNamesToCredits, artistNameToCredit, nonEmptyStringOrDefault, splitByFirstFound } from "../../../core/StringUtils.ts";
+import { artistNamesToCredits, artistNameToCredit, nonEmptyStringOrDefault, splitByFirstFound, truncateStringToLength } from "../../../core/StringUtils.ts";
 import { sleep } from "../../utils.ts";
 import { removeUndefinedKeys } from '../../../core/DataUtils.ts';
 import { writeFile } from '../../utils/FSUtils.ts';
@@ -17,13 +17,14 @@ import { LastFMUser, LastFMAuth, LastFMTrack, type LastFMUserGetRecentTracksResp
 import clone from 'clone';
 import type { IncomingMessage } from "http";
 import { baseFormatPlayObj } from "../../utils/PlayTransformUtils.ts";
-import { AuthError, ScrobbleSubmitError } from "../errors/MSErrors.ts";
+import { AuthError, ScrobbleSubmitError, SimpleError } from "../errors/MSErrors.ts";
 import { redactString } from "@foxxmd/redact-string";
 import dns from 'node:dns/promises';
 import xml2js from 'xml2js';
 import { findCauseByFunc } from "../../utils/ErrorUtils.ts";
 import * as z from 'zod';
 import { RateLimiterMemory, RateLimiterQueue, type IRateLimiterOptions } from "rate-limiter-flexible";
+import pRetry from 'p-retry';
 
 const badErrors = [
     'api key suspended',
@@ -51,6 +52,11 @@ export const LIBREFM_PATH = '/2.0/';
 export const LASTFM_HOST = 'ws.audioscrobbler.com';
 export const LASTFM_PATH = '/2.0';
 
+export interface LastfmApiData {
+    urlBase?: string, 
+    rateLimit?: Pick<IRateLimiterOptions, 'points' | 'duration'>
+}
+
 export default class LastfmApiClient extends AbstractApiClient implements PaginatedTimeRangeListens<number> {
 
     user?: string;
@@ -68,7 +74,7 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
 
     reqQueue?: RateLimiterQueue;
 
-    constructor(name: any, config: Partial<LastfmData> & {urlBase?: string, rateLimit?: Pick<IRateLimiterOptions, 'points' | 'duration'>}, options: AbstractApiOptions & InternalConfigOptional & {type?: string}) {
+    constructor(name: any, config: Partial<LastfmData> & LastfmApiData, options: AbstractApiOptions & InternalConfigOptional & {type?: string}) {
         const {type = 'lastfm', configDir, localUrl} = options ?? {};
         super(type, name, config, options);
         const {
@@ -78,6 +84,8 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
             session, 
             urlBase = `https://${LASTFM_HOST}${LASTFM_PATH}`
         } = config;
+
+        this.sessionKey = session;
 
         this.url = normalizeWebAddress(urlBase, {removeTrailingSlash: false});
         let cbPrefix: string;
@@ -116,50 +124,86 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
             retryMultiplier = DEFAULT_RETRY_MULTIPLIER
         } = this.config;
 
-        if(this.reqQueue !== undefined) {
-            await this.reqQueue.removeTokens(1);
+        const limitedCallFunc = async () => {
+            if (this.reqQueue !== undefined) {
+                this.logger.info('pre limiter');
+                await this.reqQueue.removeTokens(1);
+                this.logger.info('post limiter');
+            }
+            this.logger.info('making api call');
+            return await func() as T;
         }
 
         try {
-            return await func() as T;
-        } catch (e) {
-            const {
-                message,
-            } = e;
-            if('content' in e) {
-                let msg = 'Raw Response';
-                if('response' in e) {
-                    msg = `(${(e.response as IncomingMessage).statusCode}) ${msg}`;
-                }
-                this.logger.error(`${msg}:\n${e.content}`);
-            }
-            // for now check for exceptional errors by matching error code text
-            const retryError = retryErrors.find(x => message.toLocaleLowerCase().includes(x));
-            let networkError =  undefined;
-            if(retryError === undefined) {
-                const nError = getNodeNetworkException(e);
-                if(nError !== undefined) {
-                    networkError = nError.message;
-                } else if(message.includes('ETIMEDOUT')) {
-                    networkError = 'request timed out after 3 seconds'
-                }
-            }
-            if (undefined !== retryError || networkError !== undefined) {
-                if (retries < maxRequestRetries) {
-                    const delay = (retries + 1) * retryMultiplier;
-                    if(networkError !== undefined) {
-                        this.logger.warn(`API call failed due to network issue (${networkError}), retrying in ${delay} seconds...`);
-                    } else {
-                        this.logger.warn(`API call was not good but recoverable (${retryError}), retrying in ${delay} seconds...`);
-                    }
-                    await sleep(delay * 1000);
-                    return this.callApi(func, retries + 1);
-                } else {
-                    throw new UpstreamError(`API call failed due -> ${retryError ?? 'API call timed out'} <- after max retries hit ${maxRequestRetries}`, {cause: e})
-                }
-            }
+            return await pRetry(() => limitedCallFunc(), {
+                retries: maxRequestRetries,
+                factor: retryMultiplier,
+                minTimeout: 300,
+                maxRetryTime: 30000,
+                onFailedAttempt: (context) => {
+                    const { error, attemptNumber, retriesLeft } = context;
+                    const parts: string[] = [];
+                    let shouldThrow = false;
+                    if (error instanceof LastFMResponseError) {
+                        const status = error.response.statusCode;
+                        parts.push(`HTTP ${status}`);
+                        parts.push(error.message);
+                        if (status === 429) {
+                            parts.push('Api call failed due to too many requests');
+                        } else if (error.message.includes('Expected JSON response')) {
+                            parts.push('Api call failed due unexpected non-json response');
+                            if (error.content !== undefined) {
+                                // add some truncated response content
+                                parts.push(`Contents (truncated): ${truncateStringToLength(100, error.content)}`);
+                            }
+                        } else {
+                            const retryError = retryErrors.find(x => error.message.toLocaleLowerCase().includes(x));
+                            let networkError = undefined;
+                            if (retryError === undefined) {
+                                const nError = getNodeNetworkException(error);
+                                if (nError !== undefined) {
+                                    networkError = nError.message;
+                                } else if (error.message.includes('ETIMEDOUT')) {
+                                    networkError = 'request timed out after 3 seconds'
+                                }
+                                if(networkError !== undefined) {
+                                    parts.push(`Api call failed due to a network issue: ${retryError}`);
+                                } else {
+                                    parts.push(`Api call failed for a non-retryable reason`);
+                                    shouldThrow = true;
+                                }
+                            } else {
+                                parts.push(`Api call failed due to a retryable error: ${retryError}`);
+                            }
+                        }
 
-            throw e;
+                        const reasonError = new SimpleError(parts.join(' | '), {cause: error});
+                        if(shouldThrow) {
+                            throw new SimpleError(`Request attempt ${attemptNumber} failed with non-retryable reason`, {cause: reasonError, shortStack: true});
+                        }
+                        this.logger.warn(new SimpleError(`Request attempt ${attemptNumber} failed. ${retriesLeft} retries left`, {cause: reasonError, shortStack: true}));
+                    } else {
+                        let networkError: string;
+                        const nError = getNodeNetworkException(error);
+                        if(nError !== undefined) {
+                            networkError = nError.message;
+                        } else if(error.message.includes('ETIMEDOUT')) {
+                            networkError = 'request timed out after 3 seconds'
+                        }
+                        if(networkError === undefined) {
+                            throw new SimpleError(`Request attempt ${attemptNumber} failed with non-retryable reason`, {cause: error, shortStack: true});
+                        }
+                        const reasonError = new SimpleError(networkError, {cause: error});
+                        this.logger.warn(new SimpleError(`Request attempt ${attemptNumber} failed. ${retriesLeft} retries left`, {cause: reasonError, shortStack: true}));
+                    }
+                }
+            });
+        } catch (e) {
+            if('cause' in e) {
+                // likely this is a caught error from above meaning its from the api and not an MS code error
+                throw new UpstreamError('API call failed', {cause: e});
+            }
+            throw new Error('API call failed unexpectedly', {cause: e});
         }
     }
 
@@ -224,14 +268,14 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
         });
     }
 
-    initialize = async (): Promise<true> => {
+    initialize = async (opts: {sessionKey?: string, name?: string} = {}): Promise<true> => {
 
         try {
             this.logger.debug(`Trying to load credentials from file path: ${this.workingCredsPath}`);
             const creds = await readJson(this.workingCredsPath, {throwOnNotFound: false, interpolateEnvs: false});
             const {sessionKey, name, lastRefreshed} = creds || {};
-            this.sessionKey = sessionKey;
-            this.user = name;
+            this.sessionKey = sessionKey ?? opts.sessionKey;
+            this.user = name ?? opts.name;
             if(lastRefreshed !== undefined) {
                 this.lastRefreshed = lastRefreshed;
             }

--- a/src/backend/common/vendor/LastfmApiClient.ts
+++ b/src/backend/common/vendor/LastfmApiClient.ts
@@ -17,12 +17,13 @@ import { LastFMUser, LastFMAuth, LastFMTrack, type LastFMUserGetRecentTracksResp
 import clone from 'clone';
 import type { IncomingMessage } from "http";
 import { baseFormatPlayObj } from "../../utils/PlayTransformUtils.ts";
-import { AuthError, ScrobbleSubmitError, SimpleError } from "../errors/MSErrors.ts";
+import { AuthError, ScrobbleSubmitError } from "../errors/MSErrors.ts";
 import { redactString } from "@foxxmd/redact-string";
 import dns from 'node:dns/promises';
 import xml2js from 'xml2js';
 import { findCauseByFunc } from "../../utils/ErrorUtils.ts";
 import * as z from 'zod';
+import { RateLimiterMemory, RateLimiterQueue, type IRateLimiterOptions } from "rate-limiter-flexible";
 
 const badErrors = [
     'api key suspended',
@@ -65,7 +66,9 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
     userApi!: LastFMUser;
     trackApi!: LastFMTrack;
 
-    constructor(name: any, config: Partial<LastfmData> & {urlBase?: string}, options: AbstractApiOptions & InternalConfigOptional & {type?: string}) {
+    reqQueue?: RateLimiterQueue;
+
+    constructor(name: any, config: Partial<LastfmData> & {urlBase?: string, rateLimit?: Pick<IRateLimiterOptions, 'points' | 'duration'>}, options: AbstractApiOptions & InternalConfigOptional & {type?: string}) {
         const {type = 'lastfm', configDir, localUrl} = options ?? {};
         super(type, name, config, options);
         const {
@@ -95,6 +98,11 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
             }
         }
 
+        if(config.rateLimit !== undefined) {
+            this.logger.verbose(`Rate limiting requests => ${config.rateLimit.points}req/${config.rateLimit.duration}s`);
+            this.reqQueue = new RateLimiterQueue(new RateLimiterMemory({points: config.rateLimit.points, duration: config.rateLimit.duration}), {maxQueueSize: 20});
+        }
+
         this.redirectUri = `${redirectUri ?? joinedUrl(localUrl, `${cbPrefix}/callback`).href}?state=${normalizeStr(this.name, {keepSingleWhitespace: false})}`;
 
         this.logger.info(`Using ${this.url.normal} for API calls`);
@@ -107,6 +115,10 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
             maxRequestRetries = 2,
             retryMultiplier = DEFAULT_RETRY_MULTIPLIER
         } = this.config;
+
+        if(this.reqQueue !== undefined) {
+            await this.reqQueue.removeTokens(1);
+        }
 
         try {
             return await func() as T;
@@ -247,6 +259,7 @@ export default class LastfmApiClient extends AbstractApiClient implements Pagina
         } catch (e) {
             const hint = e.error?.cause?.message ?? undefined;
              
+            // eslint-disable-next-line preserve-caught-error
             throw new Error(`Could not connect to ${this.upstreamName} API server${hint !== undefined ? ` (${hint})` : ''}`, { cause: e.error ?? e });
         }
     }

--- a/src/backend/common/vendor/ListenbrainzApiClient.ts
+++ b/src/backend/common/vendor/ListenbrainzApiClient.ts
@@ -137,8 +137,6 @@ export class ListenbrainzApiClient extends AbstractApiClient implements Pageless
             retryMultiplier = DEFAULT_RETRY_MULTIPLIER
         } = this.config;
 
-        const thisInstance = this;
-
         const {
             retries = maxRequestRetries,
             logFailure = true
@@ -150,9 +148,9 @@ export class ListenbrainzApiClient extends AbstractApiClient implements Pageless
                 factor: retryMultiplier,
                 minTimeout: 1000,
                 maxRetryTime: 30000,
-                onFailedAttempt(context) {
+                onFailedAttempt: (context) => {
                     if(logFailure) {
-                        thisInstance.logger.warn(new SimpleError(`Request attempt ${context.attemptNumber} failed. ${context.retriesLeft} retries left`, {cause: context.error, shortStack: true}));                
+                        this.logger.warn(new SimpleError(`Request attempt ${context.attemptNumber} failed. ${context.retriesLeft} retries left`, {cause: context.error, shortStack: true}));                
                     }
                    },
                 shouldRetry(context) {

--- a/src/backend/common/vendor/musicbrainz/MusicbrainzApiClient.ts
+++ b/src/backend/common/vendor/musicbrainz/MusicbrainzApiClient.ts
@@ -21,7 +21,7 @@ import type {IRecordingMSList} from '../../transforms/MusicbrainzTransformer.ts'
 import dayjs, { type Dayjs } from 'dayjs';
 import { artistCreditsToNames } from '../../../../core/StringUtils.ts';
 import { isrcNoHyphens } from '../../../../core/PlayUtils.ts';
-
+import { RateLimiterMemory, RateLimiterQueue } from 'rate-limiter-flexible';
 export interface SubmitResponse {
     payload?: {
         ignored_listens: number
@@ -33,8 +33,7 @@ export interface SubmitResponse {
 export interface MusicbrainzApiConfig extends MusicbrainzApiConfigData {
     api: MusicBrainzApi,
     hostname: string
-    minRequestIntervalDuration: number
-    lastRequest: Dayjs
+    reqQueue: RateLimiterQueue
 }
 
 export interface MusicbrainzApiClientConfig {
@@ -58,7 +57,7 @@ export class MusicbrainzApiClient extends AbstractApiClient {
     cache: Cacheable;
     protected asyncStore: AsyncLocalStorage<string>;
 
-    constructor(name: any, config: MusicbrainzApiClientConfig, options: AbstractApiOptions & {cache?: Cacheable, logUrl?: boolean}) {
+    constructor(name: any, config: MusicbrainzApiClientConfig, options: AbstractApiOptions & {cache?: Cacheable, logUrl?: boolean, reqQueueDuration?: number}) {
         super('Musicbrainz', name, config, options);
 
         this.asyncStore = new AsyncLocalStorage();
@@ -71,8 +70,7 @@ export class MusicbrainzApiClient extends AbstractApiClient {
             const mbApiConfig: Omit<MusicbrainzApiConfig, 'api'> = {
                 ...mbConfig, 
                 hostname: u.url.hostname, 
-                minRequestIntervalDuration: 1000, 
-                lastRequest: dayjs().subtract(1000 + 1000, 'ms')
+                reqQueue: new RateLimiterQueue(new RateLimiterMemory({points: 1, duration: options?.reqQueueDuration ?? 1}), {maxQueueSize: 20})
             }
             if(mb === undefined) {
                 const api = new MusicBrainzApi({
@@ -117,7 +115,6 @@ export class MusicbrainzApiClient extends AbstractApiClient {
         let apiConfig = this.rrApis.next().value;
 
         const {
-            timeout = 30000,
             cacheKey,
             useCachedResult = true
         } = options || {};
@@ -140,15 +137,8 @@ export class MusicbrainzApiClient extends AbstractApiClient {
         const triedHosts: string[] = [];
         while(!triedHosts.includes(apiConfig.hostname)) {
 
-            // keep track of last request init at and wait until at least 1 second since that
-            // to help prevent rate limiting
-            const sinceLast = dayjs().diff(apiConfig.lastRequest, 'ms');
-            const waitTime = Math.max(0, apiConfig.minRequestIntervalDuration - sinceLast);
-            apiConfig.lastRequest = dayjs().add(waitTime, 'ms');
-            //this.logger.trace(`Waiting ${waitTime}ms to call ${apiConfig.hostname} request at ${apiConfig.lastRequest.toISOString()}`)
-            if(waitTime > 0) {
-                await sleep(waitTime);
-            }
+            // rate limit at 1req/s
+            const res = await apiConfig.reqQueue.removeTokens(1);
 
             try {
                 const res = await this.callApiEndpoint(apiConfig.api, func, options);
@@ -183,7 +173,7 @@ export class MusicbrainzApiClient extends AbstractApiClient {
         }
     }
 
-    protected callApiEndpoint = async<T = Response>(mbApi: MusicBrainzApi, func: (mb: MusicBrainzApi) => Promise<any>, options?: { timeout?: number, cacheKey?: string }): Promise<T> => {
+    protected async callApiEndpoint<T = Response>(mbApi: MusicBrainzApi, func: (mb: MusicBrainzApi) => Promise<any>, options?: { timeout?: number, cacheKey?: string }): Promise<T> {
         const {
             timeout = 30000,
             cacheKey

--- a/src/backend/scrobblers/LastfmScrobbler.ts
+++ b/src/backend/scrobblers/LastfmScrobbler.ts
@@ -3,7 +3,7 @@ import type EventEmitter from "events";
 import {COMPONENT_AUTH_TYPE, type ComponentAuthType, type PlayObject, type SourcePlayerObj} from "../../core/Atomic.ts";
 import { buildTrackString, capitalize } from "../../core/StringUtils.ts";
 import { isNodeNetworkException } from "../common/errors/NodeErrors.ts";
-import type {FormatPlayObjectOptions, InternalConfigOptional, TimeRangeListensFetcher} from "../common/infrastructure/Atomic.ts";
+import type {AbstractApiOptions, FormatPlayObjectOptions, InternalConfigOptional, TimeRangeListensFetcher} from "../common/infrastructure/Atomic.ts";
 import type {LastfmClientConfig} from "../common/infrastructure/config/client/lastfm.ts";
 import LastfmApiClient, { LastFMIgnoredScrobble, playToClientPayload, formatPlayObj } from "../common/vendor/LastfmApiClient.ts";
 import AbstractScrobbleClient, { nowPlayingUpdateByPlayDuration } from "./AbstractScrobbleClient.ts";
@@ -18,23 +18,25 @@ export default class LastfmScrobbler extends AbstractScrobbleClient {
     requiresAuthInteraction = true;
     upstreamType: string = 'Last.fm';
     getScrobblesForTimeRange: TimeRangeListensFetcher
+    protected internalOptions: InternalConfigOptional & AbstractApiOptions;
 
     declare config: LastfmClientConfig;
 
-    constructor(name: any, config: LastfmClientConfig, options: InternalConfigOptional & {[key: string]: any}, emitter: EventEmitter, logger: Logger, type = 'lastfm') {
+    constructor(name: any, config: LastfmClientConfig, options: InternalConfigOptional & AbstractApiOptions, emitter: EventEmitter, logger: Logger, type = 'lastfm') {
         super(type, name, config, emitter, logger);
-        this.api = new LastfmApiClient(name, config.data, {...options, logger});
+        this.internalOptions = options;
         // https://www.last.fm/api/show/user.getRecentTracks
         this.MAX_INITIAL_SCROBBLES_FETCH = 100;
         this.supportsNowPlaying = true;
         // last.fm shows Now Playing for the same time as the duration of the track being submitted
         this.nowPlayingMaxThreshold = nowPlayingUpdateByPlayDuration;
-        this.getScrobblesForTimeRange = createGetScrobblesForTimeRangeFunc(this.api, this.api.logger);
     }
 
     formatPlayObj = (obj: any, options: FormatPlayObjectOptions = {}) => formatPlayObj(obj, options);
 
     protected async doBuildInitData(): Promise<true | string | undefined> {
+        this.api = new LastfmApiClient(this.name, this.config.data, {...this.internalOptions, type: 'lastfm', logger: this.logger});
+        this.getScrobblesForTimeRange = createGetScrobblesForTimeRangeFunc(this.api, this.api.logger);
         await this.api.initialize();
         return true;
     }

--- a/src/backend/scrobblers/LibrefmScrobbler.ts
+++ b/src/backend/scrobblers/LibrefmScrobbler.ts
@@ -2,16 +2,17 @@ import type {EventEmitter} from "events";
 import type {Logger} from "@foxxmd/logging";
 import LastfmScrobbler from "./LastfmScrobbler.ts";
 import type {LibrefmClientConfig} from "../common/infrastructure/config/client/librefm.ts";
-import { formatPlayObj, LIBREFM_HOST, LIBREFM_PATH } from "../common/vendor/LastfmApiClient.ts";
+import LastfmApiClient, { formatPlayObj, LIBREFM_HOST, LIBREFM_PATH } from "../common/vendor/LastfmApiClient.ts";
 import type {LastfmClientConfig, LastfmData} from "../common/infrastructure/config/client/lastfm.ts";
-import type {FormatPlayObjectOptions, InternalConfigOptional} from "../common/infrastructure/Atomic.ts";
+import type {AbstractApiOptions, FormatPlayObjectOptions, InternalConfigOptional} from "../common/infrastructure/Atomic.ts";
+import { createGetScrobblesForTimeRangeFunc } from "../utils/ListenFetchUtils.ts";
 
 export default class LibrefmScrobbler extends LastfmScrobbler {
 
-        // @ts-expect-error
+        // @ts-expect-error its fine
         declare config: LibrefmClientConfig;
 
-        constructor(name: any, config: LibrefmClientConfig, options: InternalConfigOptional & {[key: string]: any},  emitter: EventEmitter, logger: Logger) {
+        constructor(name: any, config: LibrefmClientConfig, options: InternalConfigOptional & AbstractApiOptions,  emitter: EventEmitter, logger: Logger) {
             const {
                 data: {
                     urlBase = `https://${LIBREFM_HOST}${LIBREFM_PATH}`,
@@ -23,6 +24,13 @@ export default class LibrefmScrobbler extends LastfmScrobbler {
             config.data = {...(rest as LastfmData), urlBase, apiKey, secret};
             super(name, config as LastfmClientConfig, {...options, type: 'librefm'}, emitter, logger, 'librefm');
             this.upstreamType = 'Libre.fm';
+        }
+
+        protected async doBuildInitData(): Promise<true | string | undefined> {
+            this.api = new LastfmApiClient(this.name, {...this.config.data, rateLimit: {points: 1, duration: 1}}, {...this.internalOptions, logger: this.logger});
+            this.getScrobblesForTimeRange = createGetScrobblesForTimeRangeFunc(this.api, this.api.logger);
+            await this.api.initialize();
+            return true;
         }
 
         formatPlayObj = (obj: any, options: FormatPlayObjectOptions = {}) => formatPlayObj(obj, {...options, source: 'Librefm'});

--- a/src/backend/sources/LastfmSource.ts
+++ b/src/backend/sources/LastfmSource.ts
@@ -21,6 +21,7 @@ export default class LastfmSource extends MemorySource {
     requiresAuthInteraction = true;
     upstreamType: string = 'Last.fm';
     getScrobblesForTimeRange: TimeRangeListensFetcher
+    protected internalOptions: InternalConfig;
 
     declare config: LastfmSourceConfig;
 
@@ -37,12 +38,10 @@ export default class LastfmSource extends MemorySource {
         this.canBacklog = true;
         this.supportsUpstreamRecentlyPlayed = true;
         this.supportsUpstreamNowPlaying = true;
-        this.api = new LastfmApiClient(name, config.data, {logger: this.logger, type, ...internal});
         this.playerSourceOfTruth = SOURCE_SOT.HISTORY;
         // https://www.last.fm/api/show/user.getRecentTracks
         this.SCROBBLE_BACKLOG_COUNT = 200;
         this.logger.info(`Note: The player for this source is an analogue for the 'Now Playing' status exposed by ${this.type} which is NOT used for scrobbling. Instead, the 'recently played' or 'history' information provided by this source is used for scrobbles.`);
-        this.getScrobblesForTimeRange = createGetScrobblesForTimeRangeFunc(this.api, this.api.logger);
     }
 
     static formatPlayObj(obj: any, options: FormatPlayObjectOptions = {}): PlayObject {
@@ -50,6 +49,8 @@ export default class LastfmSource extends MemorySource {
     }
 
     protected async doBuildInitData(): Promise<true | string | undefined> {
+        this.api = new LastfmApiClient(this.name, this.config.data, {logger: this.logger, type: 'lastfm', ...this.internalOptions});
+        this.getScrobblesForTimeRange = createGetScrobblesForTimeRangeFunc(this.api, this.api.logger);
         return await this.api.initialize();
     }
 

--- a/src/backend/sources/LibrefmSource.ts
+++ b/src/backend/sources/LibrefmSource.ts
@@ -2,9 +2,10 @@ import type {EventEmitter} from "events";
 import type {InternalConfig} from "../common/infrastructure/Atomic.ts";
 import type {LibrefmSourceConfig} from "../common/infrastructure/config/source/librefm.ts";
 import LastfmSource from "./LastfmSource.ts";
-import { LIBREFM_HOST, LIBREFM_PATH } from "../common/vendor/LastfmApiClient.ts";
+import LastfmApiClient, { LIBREFM_HOST, LIBREFM_PATH } from "../common/vendor/LastfmApiClient.ts";
 import type {LastfmData} from "../common/infrastructure/config/client/lastfm.ts";
 import type {LastfmSourceConfig} from "../common/infrastructure/config/source/lastfm.ts";
+import { createGetScrobblesForTimeRangeFunc } from "../utils/ListenFetchUtils.ts";
 
 
 export default class LibrefmSource extends LastfmSource {
@@ -24,5 +25,11 @@ export default class LibrefmSource extends LastfmSource {
         config.data = {...(rest as LastfmData), urlBase, apiKey, secret};
         super(name, config as LastfmSourceConfig, internal, emitter, 'librefm');
         this.upstreamType = 'Libre.fm';
+    }
+
+    protected async doBuildInitData(): Promise<true | string | undefined> {
+        this.api = new LastfmApiClient(this.name, {...this.config.data, rateLimit: {points: 1, duration: 1}}, {logger: this.logger, type: 'librefm', ...this.internalOptions});
+        this.getScrobblesForTimeRange = createGetScrobblesForTimeRangeFunc(this.api, this.api.logger);
+        return await this.api.initialize();
     }
 }

--- a/src/backend/tests/lastfm/lastfm.test.ts
+++ b/src/backend/tests/lastfm/lastfm.test.ts
@@ -3,8 +3,16 @@ import asPromised from 'chai-as-promised';
 import { describe, it } from 'mocha';
 import { generateLastfmTrackObject, generateMbid, generatePlay } from "../../../core/tests/utils/PlayTestUtils.ts";
 
-import { playToClientPayload, formatPlayObj } from '../../common/vendor/LastfmApiClient.ts';
+import LastfmApiClient, { playToClientPayload, formatPlayObj } from '../../common/vendor/LastfmApiClient.ts';
 import { artistNamesToCredits } from '../../../core/StringUtils.ts';
+import { withRequestInterception } from '../utils/networking.ts';
+import { http, HttpResponse } from "msw";
+import { loggerDebug, loggerTest } from '@foxxmd/logging';
+import { findCauseByReference } from '../../utils/ErrorUtils.ts';
+import { LastFMResponseError } from 'lastfm-ts-api';
+import { SimpleError } from '../../common/errors/MSErrors.ts';
+import {spy} from 'sinon';
+import { sleep } from '../../utils.ts';
 
 chai.use(asPromised);
 
@@ -66,26 +74,103 @@ describe('#LFM Track to Play', function() {
 
 });
 
-// it('should catch error and log contents on api failure', async function () {
-//     this.timeout(50000);
-//     await withRequestInterception([
-//         http.post('ws.audioscrobbler.com/2.0', async () => {
-//             return HttpResponse.html('<html>This is a test</html>', {status: 200});
-//         })
-//     ], async function () {
+describe('#LFM Error Response Handling', function () {
 
-//         const lfm = new LastfmApiClient('mylfm-client-test', {
-//             apiKey: '',
-//             secret: ''
-//         }, {
-//             logger: loggerDebug,
-//             localUrl: new URL('http://localhost:9078'),
-//             configDir: configDir,
-//             version: 'test'
-//         });
+    it('should catch error and include unexpected json message', async function () {
+        await withRequestInterception([
+            http.all('https://lfmtest.local/2.0', async () => {
+                return HttpResponse.html('<html>You have made too many retries</html>', { status: 429 });
+            })
+        ], async function () {
 
-//         await lfm.initialize();
+            const lfm = new LastfmApiClient('mylfm-client-test', {
+                apiKey: '',
+                secret: '',
+                session: '',
+                urlBase: 'https://lfmtest.local/2.0'
+            }, {
+                logger: loggerTest,
+                localUrl: new URL('http://localhost:9078'),
+                configDir: '.',
+                version: 'test'
+            });
 
-//         await lfm.testAuth();
-//     })();
-// });
+            await lfm.initialize({ name: 'test', sessionKey: 'test' });
+
+            try {
+                await lfm.testAuth();
+            } catch (e) {
+                const cause = findCauseByReference(e, LastFMResponseError);
+                expect(cause).is.not.undefined;
+                expect(cause.message).includes('Expected JSON response');
+            }
+        })();
+    });
+
+    it('should catch non-retryable error', async function () {
+        await withRequestInterception([
+            http.all('https://lfmtest.local/2.0', async () => {
+                return HttpResponse.json({ error: { '#text': 'unspecified resource', code: 7 } }, { status: 200 });
+            })
+        ], async function () {
+
+            const lfm = new LastfmApiClient('mylfm-client-test', {
+                apiKey: '',
+                secret: '',
+                session: '',
+                urlBase: 'https://lfmtest.local/2.0'
+            }, {
+                logger: loggerTest,
+                localUrl: new URL('http://localhost:9078'),
+                configDir: '.',
+                version: 'test'
+            });
+
+            await lfm.initialize({ name: 'test', sessionKey: 'test' });
+
+            try {
+                await lfm.testAuth();
+            } catch (e) {
+                const cause = findCauseByReference(e, SimpleError);
+                expect(cause).is.not.undefined;
+                expect(cause.message).includes('Request attempt 1 failed');
+            }
+        })();
+    });
+});
+
+describe('#LFM Rate Limiting', function () {
+
+    it('should limit calls based on rate', async function () {
+        let callCount = 0;
+        await withRequestInterception([
+            http.all('https://lfmtest.local/2.0', async () => {
+                callCount++;
+                return HttpResponse.json({ user: {name: 'test'} }, { status: 200 });
+            })
+        ], async function () {
+
+            const lfm = new LastfmApiClient('mylfm-client-test', {
+                apiKey: '',
+                secret: '',
+                session: '',
+                urlBase: 'https://lfmtest.local/2.0',
+                rateLimit: {points: 1, duration: 0.01}
+            }, {
+                logger: loggerTest,
+                localUrl: new URL('http://localhost:9078'),
+                configDir: '.',
+                version: 'test'
+            });
+
+            await lfm.initialize({ name: 'test', sessionKey: 'test' });
+
+            //const sp = spy(lfm, 'callApi');
+            for(let i = 0; i < 5; i++) {
+                lfm.testAuth().then(() => null).catch((e) => {throw e;});
+            }
+            await sleep(31);
+            expect(callCount).to.eq(3);
+        })();
+    });
+});

--- a/src/backend/tests/musicbrainz/musicbrainz.test.ts
+++ b/src/backend/tests/musicbrainz/musicbrainz.test.ts
@@ -13,10 +13,13 @@ import type {MusicbrainzApiConfigData} from '../../common/infrastructure/Atomic.
 import { MockNetworkError, withRequestInterception } from '../utils/networking.ts';
 import { http, HttpResponse, delay } from "msw";
 import { generatePlay, withBrainz } from '../../../core/tests/utils/PlayTestUtils.ts';
-import { intersect, missingMbidTypes } from '../../utils.ts';
+import { intersect, missingMbidTypes, sleep } from '../../utils.ts';
 import { CoverArtApiClient, type CoverArtApiConfig } from '../../common/vendor/musicbrainz/CoverArtApiClient.ts';
 import { artistNamesToCredits, artistNameToCredit } from '../../../core/StringUtils.ts';
 import dayjs from 'dayjs';
+import { MusicbrainzApiClient } from '../../common/vendor/musicbrainz/MusicbrainzApiClient.ts';
+import {spy} from 'sinon';
+import type { MusicBrainzApi } from 'musicbrainz-api';
 
 chai.use(asPromised);
 
@@ -46,6 +49,12 @@ const mbTransformer = createMbTransformer();
 
 const createCoverArtApi = (config: CoverArtApiConfig = {}) => {
     return new CoverArtApiClient('test', config, {logger: loggerTest});
+}
+
+class MusicbrainzApiTestClient extends MusicbrainzApiClient {
+    callApiEndpoint = async<T = Response>(mbApi: MusicBrainzApi, func: (mb: MusicBrainzApi) => Promise<any>, options?: { timeout?: number, cacheKey?: string }): Promise<T> => {
+        return super.callApiEndpoint(mbApi, func,options);
+    }
 }
 
 describe('Musicbrainz API', function () {
@@ -565,6 +574,28 @@ describe('Musicbrainz API', function () {
 
             })();
         });
+    });
+
+    it('rate limits to 1req per duration', async function () {
+        await withRequestInterception([
+            http.get(/mbtest\.local\/?\/ws/, async () => {
+                return HttpResponse.json([], {status: 200});
+            })
+        ], async function () {
+
+            const apiClient = new MusicbrainzApiTestClient('test', {apis: [{url: 'https://mbtest.local', contact: 'test@email.com'}]}, {
+                logger: loggerTest,
+                cache: memorycache(),
+                reqQueueDuration: 0.01
+            });
+            const sp = spy(apiClient, 'callApiEndpoint');
+
+            for(let i = 0; i < 5; i++) {
+                apiClient.callApi((mb) => mb.search('recording', {})).then(() => null)
+            }
+            await sleep(30);
+            expect(sp.callCount).to.eq(3);
+        })();
     });
 
 });

--- a/src/backend/tests/utils/mswGlobalServer.ts
+++ b/src/backend/tests/utils/mswGlobalServer.ts
@@ -1,0 +1,21 @@
+import { setupServer, type SetupServer } from 'msw/node';
+
+/**
+ * Must be loaded (via .mocharc.json "file") before any spec file, and must have no
+ * other imports, so this listen() call wins the race against any library (like
+ * lastfm-ts-api) that freezes a reference to `https.request` at its own module load.
+ * @see https://github.com/nock/nock/issues/2397#issuecomment-1591090893
+ */
+import { syncBuiltinESMExports } from 'node:module';
+
+export const server: SetupServer = setupServer();
+server.listen({ onUnhandledRequest: 'bypass' });
+// Reassigning https.request/http.request only patches the CJS exports object.
+// Named ESM imports of those exports (e.g. `import { request } from 'node:https'`,
+// used by lastfm-ts-api) resolve to a snapshot taken independently of that
+// reassignment, so they never see MSW's patched version without this call.
+// @see https://nodejs.org/api/module.html#modulesyncbuiltinesmexports
+syncBuiltinESMExports();
+server.events.on('request:unhandled', ({ request }) => {
+    console.log('MSW unhandled:', request.method, request.url)
+});

--- a/src/backend/tests/utils/networking.ts
+++ b/src/backend/tests/utils/networking.ts
@@ -1,5 +1,6 @@
-import { setupServer, type SetupServer } from 'msw/node';
+import type { setupServer, SetupServer } from 'msw/node';
 import type {NodeNetworkErrorCode, NodeNetworkException} from "../../common/errors/NodeErrors.ts";
+import { server } from './mswGlobalServer.ts';
 
 export class MockNetworkError extends Error implements NodeNetworkException {
 
@@ -15,17 +16,19 @@ export class MockNetworkError extends Error implements NodeNetworkException {
 
 /**
  * Adapted from https://github.com/nock/nock/issues/2397#issuecomment-1591090893
+ *
+ * Reuses the single process-wide server from mswGlobalServer.ts instead of
+ * listen()/close() per test, since some HTTP clients (e.g. lastfm-ts-api) capture a
+ * reference to https.request at module load time and never see a re-patched one.
  * */
 
 export type ServerOptions = Parameters<typeof setupServer>;
 
 export const withRequestInterception =
     (handlers: ServerOptions, test: (server: SetupServer) => any) => async () => {
-        const server = setupServer(...handlers);
-        server.listen();
+        server.use(...handlers);
 
         return Promise.resolve(test(server)).finally(() => {
             server.resetHandlers();
-            server.close();
         });
 };


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Describe your changes

Use [`node-rate-limiter-flexible`](https://github.com/animir/node-rate-limiter-flexible)'s memory-backed [`RateLimiterQueue`](https://github.com/animir/node-rate-limiter-flexible/wiki/RateLimiterQueue) to properly rate limit and _queue_ async requests to known rate-limited services.

RateLimiterQueue replaces the race-condition prone timestamp+sleep method for musicbrainz. The queueing implementation means MS code can continue as normal with "overbudgeted" requests being queued and executed after tokens are available (at rate limit/s) instead of being rejected outright.

Additionally, implement this approach for libre.fm requests to potentially address rate limit 429's commonly seen from the main libre.fm service #663

## Issue number and link, if applicable

