### PR TITLE
docs: Adjust caddy snippet with better guidance

### DIFF
--- a/docsite/docs/configuration/security.mdx
+++ b/docsite/docs/configuration/security.mdx
@@ -183,14 +183,20 @@ Below are examples of protecting all non-ingress and callback routes with basic 
     <TabItem value="caddy" label="Caddy">
     ```Caddyfile
     multi-scrobbler.domain.tld {
+      # remove any paths you are NOT using from `not path` line.
+      # Order: LZ, LZ, WebScrobbler, LFM, LFM
       @if-not-scrobble {
         not path /1/* /api/listenbrainz* /api/webscrobbler* /2.0/* /api/lastfm*
       }
-      # if the request is to ANY route not listed above, force client to pass basic auth
+      # if request is to any route not listed above, force client to basic auth
+      # you must hash your password using `caddy hash-password`
+      # https://caddyserver.com/docs/command-line#caddy-hash-password
       basic_auth @if-not-scrobble { 
-        basicAuthUser hashedPassword
+        msUser $2a$14$.UWNn4Zn.cQHY6Z1mkXXrOhO7mg4BC2wiC.4Tb8dNBMidjSRHAw3e
       }
-      # requests will be proxied only if they are to a scrobble endpoint or basic auth has been passed.
+      # requests will be proxied they are to a scrobble endpoint or basic auth has been passed.
+      # can use container/service name if Caddy & MS are on the same docker network.
+      # otherwise, replace `multi-scrobbler` with host IP
       reverse_proxy multi-scrobbler:9078
     }
     ```


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Describe your changes
Updates the Caddy configuration snippet to be comparable to the Traefik snippet in user guidance and detail. I also tested the Caddy configuration and validated scrobbles are passed to MS without authentication, while the WebUI requires the user to pass basic authentication.

## Issue number and link, if applicable
https://github.com/FoxxMD/multi-scrobbler/issues/500#issuecomment-5492534109