### PR TITLE
fix(api): make optional query params optional in route schemas

### DIFF
--- a/src/backend/server/api.ts
+++ b/src/backend/server/api.ts
@@ -749,7 +749,7 @@ export const setupApi = (args: ApiArgs, opts: ApiOptions = {}) => {
         return res.json(result);
     });
 
-    router.get('/api/source/art', {middleware: [sourceMiddleFunc(false)], querySchema: z.object({data: z.number()}).optional(), hidden: true}, async (req, res, next) => {
+    router.get('/api/source/art', {middleware: [sourceMiddleFunc(false)], querySchema: z.object({data: z.string().optional()}).loose(), hidden: true}, async (req, res, next) => {
         const {
             scrobbleSource,
             query: {
@@ -903,7 +903,7 @@ export const setupApi = (args: ApiArgs, opts: ApiOptions = {}) => {
         return res.json(result);
     });
 
-    router.post('/api/source/init', {middleware: [sourceRequiredMiddle], querySchema: z.object({force: z.boolean()}).optional(), hidden: true}, async (req, res) => {
+    router.post('/api/source/init', {middleware: [sourceRequiredMiddle], querySchema: z.object({force: z.string().optional()}).loose(), hidden: true}, async (req, res) => {
         const source = req.scrobbleSource as AbstractSource;
 
         const {
@@ -929,7 +929,7 @@ export const setupApi = (args: ApiArgs, opts: ApiOptions = {}) => {
         }
     });
 
-    router.post('/api/source/listen', {middleware: [sourceRequiredMiddle], querySchema: z.object({listening: z.boolean()}).optional(), hidden: true}, async (req, res) => {
+    router.post('/api/source/listen', {middleware: [sourceRequiredMiddle], querySchema: z.object({listening: z.string().optional()}).loose(), hidden: true}, async (req, res) => {
         const source = req.scrobbleSource as AbstractSource;
 
         const {
@@ -949,7 +949,7 @@ export const setupApi = (args: ApiArgs, opts: ApiOptions = {}) => {
         res.status(200).json({listening});
     });
 
-    router.post('/api/client/listen', {middleware: [clientRequiredMiddle], querySchema: z.object({listening: z.boolean()}).optional(), hidden: true}, async (req, res) => {
+    router.post('/api/client/listen', {middleware: [clientRequiredMiddle], querySchema: z.object({listening: z.string().optional()}).loose(), hidden: true}, async (req, res) => {
         const client = req.scrobbleClient as AbstractScrobbleClient;
 
         const {
@@ -969,7 +969,7 @@ export const setupApi = (args: ApiArgs, opts: ApiOptions = {}) => {
         res.status(200).json({listening});
     });
 
-    router.post('/api/client/init', {middleware: [clientRequiredMiddle], querySchema: z.object({force: z.boolean()}).optional(), hidden: true}, async (req, res) => {
+    router.post('/api/client/init', {middleware: [clientRequiredMiddle], querySchema: z.object({force: z.string().optional()}).loose(), hidden: true}, async (req, res) => {
         const client = req.scrobbleClient as AbstractScrobbleClient;
 
         const {
@@ -1005,14 +1005,17 @@ export const setupApi = (args: ApiArgs, opts: ApiOptions = {}) => {
     });
 
     router.get('/health', {hidden: true}, async (req, res) => res.redirect(307, `/api/${req.url.slice(1)}`));
-    router.get('/api/health', {querySchema: z.object({type: z.string(), name: z.string()}).optional(), tags: ['App Meta']}, async (req, res) => {
+    router.get('/api/health', {querySchema: z.object({
+        type: z.string().optional().meta({description: 'Only report status for components of this type'}),
+        name: z.string().optional().meta({description: 'Only report status for the component with this name'})
+    }), tags: ['App Meta']}, async (req, res) => {
         const {
             type,
             name
         } = req.query;
 
-        const [sourcesReady, sourceMessages] = await scrobbleSources.getStatusSummary(type as string|undefined, name as string|undefined);
-        const [clientsReady, clientMessages] = await scrobbleClients.getStatusSummary(type as string|undefined, name as string|undefined);
+        const [sourcesReady, sourceMessages] = await scrobbleSources.getStatusSummary(type, name);
+        const [clientsReady, clientMessages] = await scrobbleClients.getStatusSummary(type, name);
 
 
         return res.status((clientsReady && sourcesReady) ? 200 : 500).json({messages: sourceMessages.concat(clientMessages)});

--- a/src/backend/tests/server/health.test.ts
+++ b/src/backend/tests/server/health.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import request from 'supertest';
+import { loggerTest } from '@foxxmd/logging';
+import ScrobbleSources from '../../sources/ScrobbleSources.ts';
+import ScrobbleClients from '../../scrobblers/ScrobbleClients.ts';
+import { WildcardEmitter } from '../../common/WildcardEmitter.ts';
+import { initServer } from '../../server/index.ts';
+import type { ListenbrainzEndpointSourceConfig } from '../../common/infrastructure/config/source/endpointlz.ts';
+
+const internalConfig = { localUrl: new URL('https://example.com'), configDir: 'fake', logger: loggerTest, version: 'test' };
+
+const defaultLzConfig: ListenbrainzEndpointSourceConfig & { source: string } = {
+    id: 'test',
+    enable: true,
+    data: {},
+    source: 'file'
+};
+
+const buildApp = async () => {
+    const sources = new ScrobbleSources(new WildcardEmitter(), internalConfig, loggerTest);
+    await sources.addSource('endpointlz', [defaultLzConfig]);
+    const clients = new ScrobbleClients(new WildcardEmitter(), new WildcardEmitter(), internalConfig, loggerTest);
+    const [app] = await initServer({ sources, clients }, { testMode: true });
+    return app;
+};
+
+describe('Health Endpoint', function () {
+
+    it('accepts a request with no query parameters', async function () {
+        const response = await request(await buildApp()).get('/api/health');
+
+        expect(response.status).to.not.eq(400);
+        expect(response.body).to.have.property('messages');
+    });
+
+    it('accepts a request filtered by type and name', async function () {
+        const response = await request(await buildApp())
+            .get('/api/health')
+            .query({ type: 'endpointlz', name: 'test' });
+
+        expect(response.status).to.not.eq(400);
+        expect(response.body).to.have.property('messages');
+    });
+
+    it('accepts a request filtered by only one of type or name', async function () {
+        const app = await buildApp();
+
+        for (const query of [{ type: 'endpointlz' }, { name: 'test' }]) {
+            const response = await request(app).get('/api/health').query(query);
+            expect(response.status, JSON.stringify(query)).to.not.eq(400);
+            expect(response.body, JSON.stringify(query)).to.have.property('messages');
+        }
+    });
+
+    it('follows the /health redirect while preserving the query string', async function () {
+        const response = await request(await buildApp())
+            .get('/health?type=endpointlz')
+            .redirects(1);
+
+        expect(response.status).to.not.eq(400);
+        expect(response.body).to.have.property('messages');
+    });
+});


### PR DESCRIPTION
Fixes #697.

## The bug

`GET /api/health` returns 400 for every request that omits `type` and `name`:

```
{"error":"Validation failed","details":[
  {"expected":"string","code":"invalid_type","path":["type"],...},
  {"expected":"string","code":"invalid_type","path":["name"],...}]}
```

The schema is `z.object({type: z.string(), name: z.string()}).optional()`. The `.optional()` is on the *object*, so it only helps when `req.query` is `undefined` — but Express always supplies a query object (`{}` for a bare URL), so the object branch always runs and both inner fields are validated as required. The OpenAPI spec reflects this too: `docs.multi-scrobbler.app/api/get-health` lists both parameters as required.

Reproduced against `@minisylar/express-typed-router@1.9.9` standalone:

```
GET  /api/health                          -> 400 Validation failed (type, name)
GET  /api/health?type=spotify&name=My     -> 200
```

## Same defect on five more routes

`/api/source/init`, `/api/source/listen`, `/api/client/init`, `/api/client/listen` and `/api/source/art` use the same `.optional()`-on-the-object shape, so `force` / `listening` / `data` are also effectively required.

Those five have a second problem: they're typed `z.boolean()` / `z.number()`, but query string values always arrive as strings, so they reject the request even when the parameter *is* supplied — which is what `sourceDucks.ts` / `clientDucks.ts` send from the UI:

```
POST /api/source/init?name=My&type=spotify            -> 400 expected boolean, received undefined
POST /api/source/init?name=My&type=spotify&force=true -> 400 expected boolean, received string
```

## The fix

Move `.optional()` onto each field. For the five hidden routes the fields become `z.string().optional()` and coercion stays where it already was — `parseBool(forceQ, false)` / `parseBool(listeningQ)` in the handlers, `parseInt` inside `PlexApiSource.getSourceArt`. Those handlers already treated the values as possibly-string, so no handler logic changes.

`/api/health` keeps `.loose()` off and gains `.meta({description})` on both params so the generated spec documents them as optional with a description.

Also drops the now-redundant `as string|undefined` casts on the two `getStatusSummary` calls — the schema already infers `string | undefined`.

## Validation

Node 24.14.0, npm install from a clean clone.

- New `src/backend/tests/server/health.test.ts` — 4 cases: no params, both params, each param alone, and the `/health` → `/api/health` redirect with a query string. All fail against `master` (`expected 400 to not equal 400`, 3 of 4) and pass with the fix.
- `npm run test:backend` → **583 passing, 25 pending**, no failures.
- `npm run build:backend:ts` → clean.
- `npx eslint src/backend/server/api.ts src/backend/tests/server/health.test.ts` → 0 errors (11 pre-existing warnings, none from this diff).

The five hidden routes keep `.loose()` so the `name` / `type` query params their middleware relies on aren't stripped; `/api/health` uses a plain object, matching `/api/components/:id/plays/:uid` above it.
