### PR TITLE
fix(dedup): match backlog plays against live-tracked duration window

### DIFF
--- a/src/backend/tests/utils/playComparisons.test.ts
+++ b/src/backend/tests/utils/playComparisons.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'mocha';
 import { existingScrobble, genericSourcePlayMatch, playsAreAddedOnly, playsAreBumpedOnly, playsAreSortConsistent } from "../../utils/PlayComparisonUtils.ts";
 import { generatePlay, generatePlays } from "../../../core/tests/utils/PlayTestUtils.ts";
 import { artistNamesToCredits } from "../../../core/StringUtils.ts";
-import type {PlayObject} from "../../../core/Atomic.ts";
+import { SCROBBLE_TS_SOC_END, type PlayObject } from "../../../core/Atomic.ts";
 
 const newPlay = generatePlay();
 
@@ -295,8 +295,14 @@ describe('Compare lists by order', function () {
                 artists: artistNamesToCredits(['CHVRCHES']),
                 duration: trackDuration,
                 playDate: start,
+                // finalized live plays are normalized to scrobbleTsSOC END with playDateCompleted set --
+                // the fix must anchor on playDate directly rather than the SOC-adjusted date, which
+                // would otherwise resolve to playDateCompleted (roughly the end, not the start) here
+                playDateCompleted: start.add(trackDuration, 's'),
                 listenedFor,
                 listenRanges: [{ start: { timestamp: clone(start) }, end: { timestamp: start.add(listenedFor, 's') } }]
+            }, {
+                scrobbleTsSOC: SCROBBLE_TS_SOC_END
             });
 
             const backlogCandidate: PlayObject = generatePlay({
@@ -321,6 +327,42 @@ describe('Compare lists by order', function () {
 
                 const res = await existingScrobble(liveCandidate, [existingLiveTrackedPlay]);
                 assert.isFalse(res.match, 'a confirmed-live candidate should not gain the loosened duration/listenedFor match');
+            });
+
+            // real observed duplicate: the live-tracked play was paused mid-listen (a gap in
+            // listenRanges), so it took longer in wall-clock time to finish (playDateCompleted)
+            // than its nominal duration -- the backlog candidate's timestamp falls after
+            // playDate + duration but still within playDate -> playDateCompleted
+            it('matches a backlog candidate landing in a paused play\'s real completion window, past its nominal duration', async function() {
+                const pausedStart = dayjs('2026-09-08T04:01:16.977Z');
+                const pausedDuration = 194;
+                const pausedCompleted = dayjs('2026-09-08T04:06:01.217Z'); // 4:44 wall-clock, longer than the 3:14 track
+                const pausedBacklogTimestamp = dayjs('2026-09-08T04:05:50.420Z'); // after playDate + duration (04:04:30), still before playDateCompleted
+
+                const pausedLiveTrackedPlay: PlayObject = generatePlay({
+                    track: "weren't for the wind",
+                    artists: artistNamesToCredits(['Ella Langley']),
+                    duration: pausedDuration,
+                    playDate: pausedStart,
+                    playDateCompleted: pausedCompleted,
+                    listenedFor: 181.25,
+                    listenRanges: [
+                        { start: { timestamp: dayjs('2026-09-08T04:01:16.989Z') }, end: { timestamp: dayjs('2026-09-08T04:02:17.330Z') } },
+                        { start: { timestamp: dayjs('2026-09-08T04:03:17.558Z') }, end: { timestamp: dayjs('2026-09-08T04:05:18.431Z') } }
+                    ]
+                }, {
+                    scrobbleTsSOC: SCROBBLE_TS_SOC_END
+                });
+
+                const pausedBacklogCandidate: PlayObject = generatePlay({
+                    track: "weren't for the wind",
+                    artists: artistNamesToCredits(['Ella Langley']),
+                    duration: pausedDuration,
+                    playDate: pausedBacklogTimestamp
+                });
+
+                const res = await existingScrobble(pausedBacklogCandidate, [pausedLiveTrackedPlay]);
+                assert.isTrue(res.match, 'a backlog candidate inside the real (paused) completion window should match even past nominal duration');
             });
         });
 

--- a/src/backend/tests/utils/playComparisons.test.ts
+++ b/src/backend/tests/utils/playComparisons.test.ts
@@ -1,8 +1,10 @@
 import { assert, expect } from 'chai';
 import clone from "clone";
+import dayjs from "dayjs";
 import { describe, it } from 'mocha';
-import { genericSourcePlayMatch, playsAreAddedOnly, playsAreBumpedOnly, playsAreSortConsistent } from "../../utils/PlayComparisonUtils.ts";
+import { existingScrobble, genericSourcePlayMatch, playsAreAddedOnly, playsAreBumpedOnly, playsAreSortConsistent } from "../../utils/PlayComparisonUtils.ts";
 import { generatePlay, generatePlays } from "../../../core/tests/utils/PlayTestUtils.ts";
+import { artistNamesToCredits } from "../../../core/StringUtils.ts";
 import type {PlayObject} from "../../../core/Atomic.ts";
 
 const newPlay = generatePlay();
@@ -275,6 +277,50 @@ describe('Compare lists by order', function () {
                 const diffPlay = generatePlay();
                 diffPlay.data.playDate = newPlay.data.playDate.add(3, 's');
                 expect(genericSourcePlayMatch(newPlay, diffPlay)).to.be.false;
+            });
+        });
+
+        describe('Backlog vs live-tracked duplicate detection', function() {
+
+            // mirrors a real observed duplicate: Spotify backlog reports a single
+            // timestamp near the END of a track, while live "Player" tracking
+            // records the actual start-to-finish window
+            const trackDuration = 244; // 4:04
+            const listenedFor = 182; // 3:02 -- tracker stopped short of full duration
+            const start = dayjs('2024-01-01T13:18:38.000Z');
+            const backlogTimestamp = start.add(223, 's'); // 13:22:21 -- inside duration window, outside listenedFor window, and not within 10s of matching duration exactly (diff from duration is 21s)
+
+            const existingLiveTrackedPlay: PlayObject = generatePlay({
+                track: 'Empty Threat',
+                artists: artistNamesToCredits(['CHVRCHES']),
+                duration: trackDuration,
+                playDate: start,
+                listenedFor,
+                listenRanges: [{ start: { timestamp: clone(start) }, end: { timestamp: start.add(listenedFor, 's') } }]
+            });
+
+            const backlogCandidate: PlayObject = generatePlay({
+                track: 'Empty Threat',
+                artists: artistNamesToCredits(['CHVRCHES']),
+                duration: trackDuration,
+                playDate: backlogTimestamp
+            });
+            // backlog candidate: no newFromSource, no listenRanges of its own -- matches how Spotify's
+            // history-endpoint plays are actually built (SpotifySource.ts backlog path)
+
+            it('matches a backlog candidate whose timestamp falls within the live-tracked duration window', async function() {
+                const res = await existingScrobble(backlogCandidate, [existingLiveTrackedPlay]);
+                assert.isTrue(res.match, 'a backlog candidate landing inside the live play\'s duration window should match');
+            });
+
+            it('does NOT match the same window when the candidate is itself confirmed live', async function() {
+                // guards against swallowing a genuine back-to-back repeat: only a
+                // backlog-sourced candidate should get the loosened duration/listenedFor check
+                const liveCandidate = clone(backlogCandidate);
+                liveCandidate.meta.newFromSource = true;
+
+                const res = await existingScrobble(liveCandidate, [existingLiveTrackedPlay]);
+                assert.isFalse(res.match, 'a confirmed-live candidate should not gain the loosened duration/listenedFor match');
             });
         });
 

--- a/src/backend/utils/PlayComparisonUtils.ts
+++ b/src/backend/utils/PlayComparisonUtils.ts
@@ -1,5 +1,5 @@
 import { getListDiff, type ListDiff } from "@donedeal0/superdiff";
-import { type PlayMatchResult, type PlayObject, type PlayObjectMinimal, SOURCE_SOT, type SOURCE_SOT_TYPES, TA_DURING, TA_EXACT, TA_FUZZY, type TemporalAccuracy, type TrackStringOptions } from "../../core/Atomic.ts";
+import { type AcceptableTemporalDuringReference, type PlayMatchResult, type PlayObject, type PlayObjectMinimal, SOURCE_SOT, type SOURCE_SOT_TYPES, TA_DURING, TA_EXACT, TA_FUZZY, type TemporalAccuracy, type TrackStringOptions } from "../../core/Atomic.ts";
 import { buildTrackString, capitalize, truncateStringToLength } from "../../core/StringUtils.ts";
 import { comparingMultipleArtists, playObjDataMatch, setIntersection } from "../utils.ts";
 import { comparePlayTemporally, hasAcceptableTemporalAccuracy, temporalAccuracyToString, type TemporalPlayComparisonOptions, temporalPlayComparisonSummary } from "./TimeUtils.ts";
@@ -505,8 +505,19 @@ export const existingScrobble = async (playObjPre: PlayObject, existingScrobbles
 
                 //const referenceMatch = referenceApiScrobbleResponse !== undefined && playObjDataMatch(x, referenceApiScrobbleResponse);
 
+                // a backlog/history play only carries a single reported timestamp, often marking
+                // roughly when the track finished rather than when it started -- if the existing play
+                // was actually live-tracked (has real listenRanges) then also accept a candidate whose
+                // timestamp simply falls within that play's own start-to-duration window, since that gap
+                // can't exceed the track's own length for a genuine duplicate of the same listen
+                const candidateConfirmedLive = playObj.meta.newFromSource === true
+                    || (playObj.data.listenRanges !== undefined && playObj.data.listenRanges.length > 0);
+                const existingIsLiveTracked = x.data.listenRanges !== undefined && x.data.listenRanges.length > 0;
+                const duringReferences: AcceptableTemporalDuringReference | undefined = !candidateConfirmedLive && existingIsLiveTracked
+                    ? ['range', 'listenedFor', 'duration']
+                    : undefined;
 
-                const temporalComparison = comparePlayTemporally(x, playObj, {logger});
+                const temporalComparison = comparePlayTemporally(x, playObj, {logger, duringReferences});
                 let timeMatch = 0;
                 if(hasAcceptableTemporalAccuracy(temporalComparison.match)) {
                     timeMatch = 1;

--- a/src/backend/utils/TimeUtils.ts
+++ b/src/backend/utils/TimeUtils.ts
@@ -179,23 +179,32 @@ export const comparePlayTemporally = (existingPlay: PlayObject, candidatePlay: P
             logger.warn(new Error('Failed to compare plays based on range but will continue', {cause: e}));
         }
 
+        // NOTE: these two checks intentionally anchor on existingPlay.data.playDate directly,
+        // NOT existingTsSOCDate -- existingTsSOCDate can resolve to playDateCompleted instead of
+        // playDate depending on the play's scrobbleTsSOC, which would put the window in the wrong
+        // place entirely (starting from roughly when the track ended, not when it started)
         if(duringReferences.includes('listenedFor') && existingPlay.data.listenedFor !== undefined) {
-            if (candidateTsSOCDate.isBetween(existingTsSOCDate, existingTsSOCDate.add(existingPlay.data.listenedFor, 's'))) {
+            const listenedForEnd = existingPlay.data.playDate.add(existingPlay.data.listenedFor, 's');
+            if (candidateTsSOCDate.isBetween(existingPlay.data.playDate, listenedForEnd)) {
                 result.match = TA_DURING;
                 result.range = {
                         type: 'listenedFor',
-                        timestamps: [existingTsSOCDate, existingTsSOCDate.add(existingPlay.data.listenedFor, 's')]
+                        timestamps: [existingPlay.data.playDate, listenedForEnd]
                 }
                 return result;
             }
         }
 
         if(duringReferences.includes('duration') && existingPlay.data.duration !== undefined) {
-            if (candidateTsSOCDate.isBetween(existingTsSOCDate, existingTsSOCDate.add(existingPlay.data.duration, 's'))) {
+            // prefer the play's actual observed completion time over the nominal duration --
+            // a real listen can take longer than the track's length if it was paused partway through,
+            // and playDateCompleted reflects that real wall-clock span while playDate + duration doesn't
+            const durationEnd = existingPlay.data.playDateCompleted ?? existingPlay.data.playDate.add(existingPlay.data.duration, 's');
+            if (candidateTsSOCDate.isBetween(existingPlay.data.playDate, durationEnd)) {
                 result.match = TA_DURING;
                 result.range = {
                         type: 'duration',
-                        timestamps: [existingTsSOCDate, existingTsSOCDate.add(existingPlay.data.duration, 's')]
+                        timestamps: [existingPlay.data.playDate, durationEnd]
                 }
                 return result;
             }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the [contributing guidelines.](../blob/master/CONTRIBUTING.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Describe your changes

Spotify's play-history endpoint reports a timestamp near the end of a track, while live polling records the actual start-to-finish window. The gap is close to the track's own length, so a track discovered live shortly before a restart could get scrobbled again once the backlog catch-up ran on startup. None of the existing dedup checks (exact match, close match, or a coincidental fuzzy-duration match) covered this case.

Now, when a backlog-sourced candidate is compared against an existing play that was actually live-tracked, a timestamp landing anywhere in that play's start-to-duration window also counts as the same listen. This only applies in that direction (backlog candidate vs. live-tracked existing play), so a genuine back-to-back repeat isn't at risk of being treated as a duplicate.

**Test plan**
- [x] `npx mocha --reporter spec --grep "Backlog vs live-tracked"` - all cases pass, including one built from a real duplicate reproduced locally (a paused listen whose real completion time diverged from its nominal duration)
- [x] Full suite (`npm test`): no regressions vs `master`
- [x] Verified locally against a real backlog/live duplicate pair with trace logging - now reports Matched (score 1.00) instead of the previous 0.70/No Match

## Issue number and link, if applicable

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)
